### PR TITLE
fix: security issue with the wlan password

### DIFF
--- a/data/static/wlan.htm
+++ b/data/static/wlan.htm
@@ -18,19 +18,6 @@
                         <label class="wlanlabel">SSID:</label>
                         <span>{{ssid}}</span>
                     </div>
-                    <div>
-                        <label class="wlanlabel">Password:</label>
-                        <span id="saved-password">********</span>
-                        <button type="button" class="show-password-button" 
-                                onmousedown="toggleSavedPassword(true)" 
-                                onmouseup="toggleSavedPassword(false)" 
-                                onmouseleave="toggleSavedPassword(false)">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" class="bi bi-eye" viewBox="-1 -1 16 16">
-                                  <path d="M16 8s-3-5.5-8-5.5S0 8 0 8s3 5.5 8 5.5S16 8 16 8zM1.173 8a13.133 13.133 0 0 1 1.66-2.043C4.12 4.668 5.88 3.5 8 3.5c2.12 0 3.879 1.168 5.168 2.457A13.133 13.133 0 0 1 14.828 8a13.133 13.133 0 0 1-1.66 2.043C11.879 11.332 10.12 12.5 8 12.5c-2.12 0-3.879-1.168-5.168-2.457A13.133 13.133 0 0 1 1.172 8z"/>
-                                  <path d="M8 5a3 3 0 1 0 0 6 3 3 0 0 0 0-6zM8 6a2 2 0 1 1 0 4 2 2 0 0 1 0-4z"/>
-                              </svg>
-                        </button>
-                    </div>
                 </div>
                 <div class="new-credentials">
                     <h3>Enter New Credentials:</h3>
@@ -61,9 +48,6 @@
         <script>
             function togglePassword(show) {
                 document.getElementById('wlanPASSWORD').type = show ? 'text' : 'password';
-            }
-            function toggleSavedPassword(show) {
-                document.getElementById('saved-password').innerText = show ? '{{password}}' : '********';
             }
         </script>
     </body>

--- a/src/WebServerHandler.cpp
+++ b/src/WebServerHandler.cpp
@@ -196,8 +196,6 @@ void WebServerHandler::handle_page_wlan(AsyncWebServerRequest *request)
 
 	content.replace("{{deviceName}}", DeviceName);
 	content.replace("{{ssid}}", String(ssid));
-	content.replace("{{password}}", String(password));
-
 	request->send(200, "text/html", content);
 }
 


### PR DESCRIPTION
Summary
Removes plaintext WLAN password exposure from the web interface.
Problem
The saved WLAN password was embedded as plaintext in the HTML response via the {{password}} template placeholder. Any user viewing the page source could read the password in clear text. Since the web interface has no authentication, this affected anyone on the local network.
Changes
data/static/wlan.htm

Removed the "Saved Credentials" section entirely (SSID and password display)
Removed toggleSavedPassword() JavaScript function
The SSID pre-fill in the input field is retained for usability

src/WebServerHandler.cpp

Removed content.replace("{{password}}", ...) — password is no longer sent to the client
The {{ssid}} placeholder is retained as it is still needed for the input field pre-fill

Security Note
A fully secure solution would require authentication on the web interface. Since this device operates on a trusted home network, removing the password exposure is considered sufficient for this use case.
Testing

Open the WLAN settings page and verify the saved credentials section is no longer visible
Verify the SSID is still pre-filled in the input field
Verify "View Page Source" no longer contains the WLAN password