### PR TITLE
Prerelease

### DIFF
--- a/data/static/index.htm
+++ b/data/static/index.htm
@@ -11,7 +11,7 @@
                     <a href='/status' class="button">Status</a>
                     <a href='/json' class="button">JSON File</a>
                     <a href='/WLAN' class="button">WLAN Settings</a>
-                    <a href='/sensorsettings' class="button">Sensor Settings</a>
+                    <a href='/settings' class="button">Sensor Settings</a>
                 </div>
         </div>
         <div class="footer">&copy; 2025 SensorTurtle</div>

--- a/data/static/index.htm
+++ b/data/static/index.htm
@@ -8,6 +8,9 @@
     </head>
     <body>
         <div class="container">
+            <div class="title">
+                <h1>{{deviceName}}</h1>
+            </div>
             <div class="nav">
                 <a href="/status" class="button">Status</a>
                 <a href="/json" class="button">JSON</a>
@@ -15,7 +18,6 @@
                 <a href="/sensorsettings" class="button">Sensor Settings</a>
             </div>
             <div class="content">
-                <h1>{{deviceName}}</h1>
             </div>
         </div>
         <div class="footer">&copy; 2025 SensorTurtle</div>

--- a/data/static/index.htm
+++ b/data/static/index.htm
@@ -1,18 +1,22 @@
+<!DOCTYPE html>
 <html>
     <head>
+        <meta charset="utf-8">
         <title>{{deviceName}}</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="stylesheet" href="/static/style.css">
     </head>
     <body>
         <div class="container">
+            <div class="nav">
+                <a href="/status" class="button">Status</a>
+                <a href="/json" class="button">JSON</a>
+                <a href="/WLAN" class="button">WLAN Settings</a>
+                <a href="/sensorsettings" class="button">Sensor Settings</a>
+            </div>
+            <div class="content">
                 <h1>{{deviceName}}</h1>
-                <div class="nav">
-                    <a href='/status' class="button">Status</a>
-                    <a href='/json' class="button">JSON File</a>
-                    <a href='/WLAN' class="button">WLAN Settings</a>
-                    <a href='/settings' class="button">Sensor Settings</a>
-                </div>
+            </div>
         </div>
         <div class="footer">&copy; 2025 SensorTurtle</div>
     </body>

--- a/data/static/setting.htm
+++ b/data/static/setting.htm
@@ -93,13 +93,22 @@
                         </div>
                     </form>
                 </div>
-                <h1>ESP32 Option</h1>
-                <form action="/restart" method="POST">
-                    <button type="submit" class="btn" id="resetESP32Btn">restart ESP32</button>
-                </form>
-                <form action="/restoredefaultconfiguration" method="POST">
-                    <button type="submit" class="btn" id="restoreDefaultsConfigBtn" onclick="loadDefaults()">Load Default Configuration</button>
-                </form>
+                <div>
+                    <h1>Sensor Option</h1>
+                    <form action="/calibrateMHZ19" method="POST">
+                        <button type="submit" class="btn" id="resetMHZ19SensorBtn">Calibrate MHZ19</button>
+                    </form>
+                </div>
+                <div>
+                    <h1>ESP32 Option</h1>
+                    <form action="/restart" method="POST">
+                        <button type="submit" class="btn" id="resetESP32Btn">restart ESP32</button>
+                    </form>
+                    <form action="/restoredefaultconfiguration" method="POST">
+                        <button type="submit" class="btn" id="restoreDefaultsConfigBtn" onclick="loadDefaults()">Load Default Configuration</button>
+                    </form>
+                </div>
+                
             </div>
         </div>
         <div class="footer">&copy; 2025 SensorTurtle</div>
@@ -187,6 +196,26 @@
                     .catch(error => {
                         console.error("Error:", error);
                     });
+                });
+                const calibrateForm = document.querySelector('form[action="/calibrateMHZ19"]');
+                calibrateForm.addEventListener("submit", function (event) {
+                    event.preventDefault(); 
+                    if (confirm("Are you sure you want to calibrate the MHZ19 sensor? Make sure the sensor is in fresh air (400 ppm).")) {
+                        fetch("/calibrateMHZ19", {
+                            method: "POST",
+                        })
+                        .then(response => {
+                            if (response.ok) {
+                                alert("Calibration started successfully!");
+                            } else {
+                                alert("Failed to start calibration. Please try again.");
+                            }
+                        })
+                        .catch(error => {
+                            console.error("Error:", error);
+                            alert("An error occurred while starting calibration.");
+                        });
+                    }
                 });
 
             });

--- a/data/static/settings.htm
+++ b/data/static/settings.htm
@@ -12,7 +12,7 @@
                 <a href="/index" class="button">Back to Index</a>
             </div>
             <div class="content">
-                <div>
+                <div id="switchConfig">
                     <h1>Module Switch</h1>
                     <form action="/submitmodulswitch" method="POST" id="moduleSwitchForm">
                         <div>
@@ -38,7 +38,23 @@
                         <button type="submit" class="btn" id="saveModulBtn">Save Settings</button>
                     </form>
                 </div>
-                <div>
+                <div id="sensorConfig">
+                    <h1>Sensor Configuration</h1>
+                    <form action="/submitSensorConfig" method="POST" id="sensorConfigForm">
+                        <div>
+                            <label for="sealevelpressure">Sea Level Pressure (hPa)
+                                <input type="number" id="sealevelpressure" name="SEALEVELPRESSURE_HPA" value="{{SEALEVELPRESSURE_HPA}}" step="1">
+                            </label>
+                        </div>
+                        <div>
+                            <label for="temperatureoffset">Temperature Offset (°C)
+                                <input type="number" id="temperatureoffset" name="TEMPERATUR_OFFSET" value="{{TEMPERATUR_OFFSET}}" step="0.1">
+                            </label>
+                        </div>
+                        <button type="submit" class="btn" id="saveSensorConfigBtn">Save Sensor Config</button>
+                    </form>
+                </div>
+                <div id="intervalConfig">
                     <h1>Modul Time Interval</h1>
                     <form action="/submitmodulinterval" method="POST" id="moduleIntervalForm">
                         <div>
@@ -79,10 +95,10 @@
                         <button type="submit" class="btn" id="saveIntervalBtn">Save Interval</button>
                     </form>
                 </div>
-                <div>
+                <div id="ledConfig">
                     <h1>LED Brightness</h1>
                     <form action="/submitLEDConfig" method="POST" id="ledconfigForm">
-                        <div id="ledconfig">
+                        <div id="ledconfigSlider">
                             <label for="ledBrightness">Brightness: 
                                 <span id="brightnessValue">{{LEDbrightness}}</span>
                             </label>
@@ -93,13 +109,13 @@
                         </div>
                     </form>
                 </div>
-                <div>
+                <div id="sensorOption">
                     <h1>Sensor Option</h1>
                     <form action="/calibrateMHZ19" method="POST">
                         <button type="submit" class="btn" id="resetMHZ19SensorBtn">Calibrate MHZ19</button>
                     </form>
                 </div>
-                <div>
+                <div id="esp32Option">
                     <h1>ESP32 Option</h1>
                     <form action="/restart" method="POST">
                         <button type="submit" class="btn" id="resetESP32Btn">restart ESP32</button>
@@ -108,7 +124,6 @@
                         <button type="submit" class="btn" id="restoreDefaultsConfigBtn" onclick="loadDefaults()">Load Default Configuration</button>
                     </form>
                 </div>
-                
             </div>
         </div>
         <div class="footer">&copy; 2025 SensorTurtle</div>
@@ -218,6 +233,34 @@
                     }
                 });
 
+                const sensorConfigForm = document.getElementById("sensorConfigForm");
+                const sensorConfigInputs = sensorConfigForm.querySelectorAll('input[type="number"]');
+
+                sensorConfigForm.addEventListener("submit", function (event) {
+                    event.preventDefault();
+
+                    const sensorConfigParams = Array.from(sensorConfigInputs).map(input => {
+                        return `${encodeURIComponent(input.name)}=${encodeURIComponent(input.value)}`;
+                    }).join("&");
+
+                    fetch("/submitSensorConfig", {
+                        method: "POST",
+                        headers: {
+                            "Content-Type": "application/x-www-form-urlencoded",
+                        },
+                        body: sensorConfigParams,
+                    })
+                    .then(response => {
+                        if (response.ok) {
+                            console.log("Sensor configuration saved successfully!");
+                        } else {
+                            console.error("Failed to save sensor configuration.");
+                        }
+                    })
+                    .catch(error => {
+                        console.error("Error:", error);
+                    });
+                });
             });
         </script>
     </body>

--- a/data/static/settings.htm
+++ b/data/static/settings.htm
@@ -36,6 +36,7 @@
                             </label>
                         </div>
                         <button type="submit" class="btn" id="saveModulBtn">Save Settings</button>
+                        <div class="form-feedback" id="feedbackSwitch"></div>
                     </form>
                 </div>
                 <div id="sensorConfig">
@@ -52,6 +53,7 @@
                             </label>
                         </div>
                         <button type="submit" class="btn" id="saveSensorConfigBtn">Save Sensor Config</button>
+                        <div class="form-feedback" id="feedbackSensor"></div>
                     </form>
                 </div>
                 <div id="intervalConfig">
@@ -93,6 +95,7 @@
                             </label>
                         </div>
                         <button type="submit" class="btn" id="saveIntervalBtn">Save Interval</button>
+                        <div class="form-feedback" id="feedbackInterval"></div>
                     </form>
                 </div>
                 <div id="ledConfig">
@@ -106,6 +109,7 @@
                         </div>
                         <div id="ledsubmitbtn">
                             <button type="submit" class="btn" id="saveBrightnessBtn">Save Brightness</button>
+                            <div class="form-feedback" id="feedbackBrightness"></div>
                         </div>
                     </form>
                 </div>
@@ -133,6 +137,16 @@
 
                 const form = document.querySelector('form[action="/submitmodulswitch"]');
                 const checkboxes = form.querySelectorAll('input[type="checkbox"]');
+
+                function showFeedback(elementId, success) {
+                    const el = document.getElementById(elementId);
+                    el.textContent = success ? "Saved successfully!" : "Error saving settings.";
+                    el.className = "form-feedback " + (success ? "success" : "error");
+                    setTimeout(() => {
+                        el.textContent = "";
+                        el.className = "form-feedback";
+                    }, 3000);
+                }
         
                 form.addEventListener("submit", function (event) {
                     event.preventDefault();
@@ -146,9 +160,9 @@
                     })
                     .then(response => {
                         if (response.ok) {
-                            console.log("Settings saved successfully!");
+                            showFeedback("feedbackSwitch", true);
                         } else {
-                            console.error("Failed to save settings.");
+                            showFeedback("feedbackSwitch", false);
                         }
                     })
                     .catch(error => {
@@ -171,9 +185,9 @@
                     })
                     .then(response => {
                         if (response.ok) {
-                            console.log("Module interval settings saved successfully!");
+                            showFeedback("feedbackInterval", true);
                         } else {
-                            console.error("Failed to save module interval settings.");
+                            showFeedback("feedbackInterval", false);
                         }
                     })
                     .catch(error => {
@@ -203,9 +217,9 @@
                     })
                     .then(response => {
                         if (response.ok) {
-                            console.log("LED brightness saved successfully!");
+                            showFeedback("feedbackBrightness", true);
                         } else {
-                            console.error("Failed to save LED brightness.");
+                            showFeedback("feedbackBrightness", false);
                         }
                     })
                     .catch(error => {
@@ -252,9 +266,9 @@
                     })
                     .then(response => {
                         if (response.ok) {
-                            console.log("Sensor configuration saved successfully!");
+                            showFeedback("feedbackSensor", true);
                         } else {
-                            console.error("Failed to save sensor configuration.");
+                            showFeedback("feedbackSensor", false);
                         }
                     })
                     .catch(error => {

--- a/data/static/settings.htm
+++ b/data/static/settings.htm
@@ -1,5 +1,4 @@
-
-
+<!DOCTYPE html>
 <html>
     <head>
         <title>{{deviceName}} - Sensor Settings</title>

--- a/data/static/settings.htm
+++ b/data/static/settings.htm
@@ -147,6 +147,15 @@
                         el.className = "form-feedback";
                     }, 3000);
                 }
+                function submitForm(url, params, feedbackId) {
+                    fetch(url, {
+                        method: "POST",
+                        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+                        body: params
+                    })
+                    .then(response => showFeedback(feedbackId, response.ok))
+                    .catch(() => showFeedback(feedbackId, false));
+                }
         
                 form.addEventListener("submit", function (event) {
                     event.preventDefault();
@@ -155,19 +164,7 @@
                         return `${encodeURIComponent(checkbox.name)}=${checkbox.checked ? 1 : 0}`;
                     }).join("&");
         
-                    fetch(`/submitmodulswitch?${params}`, {
-                        method: "POST",
-                    })
-                    .then(response => {
-                        if (response.ok) {
-                            showFeedback("feedbackSwitch", true);
-                        } else {
-                            showFeedback("feedbackSwitch", false);
-                        }
-                    })
-                    .catch(error => {
-                        console.error("Error:", error);
-                    });
+                    submitForm(`/submitmodulswitch?${params}`, "", "feedbackSwitch");
                 });
 
                 const intervalForm = document.querySelector('form[action="/submitmodulinterval"]');
@@ -180,19 +177,7 @@
                         return `${encodeURIComponent(input.name)}=${encodeURIComponent(input.value)}`;
                     }).join("&");
 
-                    fetch(`/submitmodulinterval?${intervalParams}`, {
-                        method: "POST",
-                    })
-                    .then(response => {
-                        if (response.ok) {
-                            showFeedback("feedbackInterval", true);
-                        } else {
-                            showFeedback("feedbackInterval", false);
-                        }
-                    })
-                    .catch(error => {
-                        console.error("Error:", error);
-                    });
+                    submitForm(`/submitmodulinterval?${intervalParams}`, "", "feedbackInterval");
                 });
 
                 const brightnessSlider = document.getElementById("ledBrightness");
@@ -208,23 +193,7 @@
 
                     const brightness = brightnessSlider.value;
 
-                    fetch("/submitLEDConfig", {
-                        method: "POST",
-                        headers: {
-                            "Content-Type": "application/x-www-form-urlencoded", 
-                        },
-                        body: `LEDbrightness=${encodeURIComponent(brightness)}`,
-                    })
-                    .then(response => {
-                        if (response.ok) {
-                            showFeedback("feedbackBrightness", true);
-                        } else {
-                            showFeedback("feedbackBrightness", false);
-                        }
-                    })
-                    .catch(error => {
-                        console.error("Error:", error);
-                    });
+                    submitForm("/submitLEDConfig", `LEDbrightness=${encodeURIComponent(brightness)}`, "feedbackBrightness");
                 });
                 const calibrateForm = document.querySelector('form[action="/calibrateMHZ19"]');
                 calibrateForm.addEventListener("submit", function (event) {
@@ -257,23 +226,7 @@
                         return `${encodeURIComponent(input.name)}=${encodeURIComponent(input.value)}`;
                     }).join("&");
 
-                    fetch("/submitSensorConfig", {
-                        method: "POST",
-                        headers: {
-                            "Content-Type": "application/x-www-form-urlencoded",
-                        },
-                        body: sensorConfigParams,
-                    })
-                    .then(response => {
-                        if (response.ok) {
-                            showFeedback("feedbackSensor", true);
-                        } else {
-                            showFeedback("feedbackSensor", false);
-                        }
-                    })
-                    .catch(error => {
-                        console.error("Error:", error);
-                    });
+                    submitForm("/submitSensorConfig", sensorConfigParams, "feedbackSensor");
                 });
             });
         </script>

--- a/data/static/settings.htm
+++ b/data/static/settings.htm
@@ -44,12 +44,12 @@
                     <form action="/submitSensorConfig" method="POST" id="sensorConfigForm">
                         <div>
                             <label for="sealevelpressure">Sea Level Pressure (hPa)
-                                <input type="number" id="sealevelpressure" name="SEALEVELPRESSURE_HPA" value="{{SEALEVELPRESSURE_HPA}}" step="1">
+                                <input type="number" id="sealevelpressure" name="SEALEVELPRESSURE_HPA" value="{{SEALEVELPRESSURE_HPA}}" step="1" min="900" max="1100">
                             </label>
                         </div>
                         <div>
                             <label for="temperatureoffset">Temperature Offset (°C)
-                                <input type="number" id="temperatureoffset" name="TEMPERATUR_OFFSET" value="{{TEMPERATUR_OFFSET}}" step="0.1">
+                                <input type="number" id="temperatureoffset" name="TEMPERATUR_OFFSET" value="{{TEMPERATUR_OFFSET}}" step="0.1" min="-10" max="10">
                             </label>
                         </div>
                         <button type="submit" class="btn" id="saveSensorConfigBtn">Save Sensor Config</button>
@@ -61,37 +61,37 @@
                     <form action="/submitmodulinterval" method="POST" id="moduleIntervalForm">
                         <div>
                             <label for="intervalMHZ19">MHZ19 Interval (s)
-                                <input type="number" id="intervalMHZ19" name="intervalMHZ19" value="{{intervalMHZ19}}">
+                                <input type="number" id="intervalMHZ19" name="intervalMHZ19" value="{{intervalMHZ19}}" min="1">
                             </label>
                         </div>
                         <div>
                             <label for="intervalBME680">BME680 Interval (s)
-                                <input type="number" id="intervalBME680" name="intervalBME680" value="{{intervalBME680}}">
+                                <input type="number" id="intervalBME680" name="intervalBME680" value="{{intervalBME680}}" min="3">
                             </label>
                         </div>
                         <div>
                             <label for="intervalWiFi">WiFi Check Interval (s)
-                                <input type="number" id="intervalWiFi" name="intervalWiFi" value="{{intervalWiFi}}">
+                                <input type="number" id="intervalWiFi" name="intervalWiFi" value="{{intervalWiFi}}" min="1">
                             </label>
                         </div>
                         <div>
                             <label for="intervalPRINT">RAM Printout Interval (s)
-                                <input type="number" id="intervalPRINT" name="intervalPRINT" value="{{intervalPRINT}}">
+                                <input type="number" id="intervalPRINT" name="intervalPRINT" value="{{intervalPRINT}}" min="1">
                             </label>
                         </div>
                         <div>
                             <label for="intervalEPD">EPD Refresh Interval (s)
-                                <input type="number" id="intervalEPD" name="intervalEPD" value="{{intervalEPD}}">
+                                <input type="number" id="intervalEPD" name="intervalEPD" value="{{intervalEPD}}" min="1">
                             </label>
                         </div>
                         <div>
                             <label for="intervalLED">LED Update Interval (s)
-                                <input type="number" id="intervalLED" name="intervalLED" value="{{intervalLED}}">
+                                <input type="number" id="intervalLED" name="intervalLED" value="{{intervalLED}}" min="1">
                             </label>
                         </div>
                         <div>
                             <label for="intervalMQTT">MQTT Interval (s)
-                                <input type="number" id="intervalMQTT" name="intervalMQTT" value="{{intervalMQTT}}">
+                                <input type="number" id="intervalMQTT" name="intervalMQTT" value="{{intervalMQTT}}" min="1">
                             </label>
                         </div>
                         <button type="submit" class="btn" id="saveIntervalBtn">Save Interval</button>

--- a/data/static/settings.htm
+++ b/data/static/settings.htm
@@ -3,6 +3,7 @@
 <html>
     <head>
         <title>{{deviceName}} - Sensor Settings</title>
+        <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="stylesheet" href="/static/style.css">
     </head>

--- a/data/static/status.htm
+++ b/data/static/status.htm
@@ -2,6 +2,7 @@
 <html>
     <head>
         <title>{{deviceName}} - sensor data status</title>
+        <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="stylesheet" href="/static/style.css">
     </head>
@@ -11,7 +12,6 @@
                 <a href="/index" class="button">Back to Index</a>
                 <a href="/status"class="button">Refresh</a>
             </div>
-            <br>
             <div class="content">
                 <h1>Sensor Data Status</h1>
                 <div class="status-container">

--- a/data/static/status.htm
+++ b/data/static/status.htm
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML>
+<!DOCTYPE html>
 <html>
     <head>
         <title>{{deviceName}} - sensor data status</title>

--- a/data/static/style.css
+++ b/data/static/style.css
@@ -51,7 +51,7 @@ body {
   color: #666;
 }
 /*  CONFIG   */
-#moduleSwitchForm div, #moduleIntervalForm div {
+#sensorConfigForm div, #moduleSwitchForm div, #moduleIntervalForm div  {
   display: block; 
   margin-bottom: 15px;
 }
@@ -60,7 +60,7 @@ body {
   overflow: hidden;
   width: 120px; 
 }
-#moduleIntervalForm div label {
+div label {
   display: inline-block;
   width: 400px; 
 }
@@ -69,7 +69,7 @@ body {
   float: right; 
   transform: scale(1.2);
 }
-#moduleIntervalForm div label input[type="number"] {
+div label input[type="number"] {
   padding: 5px;
   font-size: 14px;
   border: 1px solid #ccc;
@@ -106,7 +106,7 @@ body {
   gap: 5px;
   width: 400px;
 }
-#ledconfig {
+#ledconfigSlider {
   display: flex;
   align-items: center;
   margin-bottom: 5px;

--- a/data/static/style.css
+++ b/data/static/style.css
@@ -150,3 +150,15 @@ div label input[type="number"] {
   color: #666;
   line-height: 1.4;
 }
+/* FEEDBACK */
+.form-feedback {
+  font-size: 14px;
+  margin-top: 8px;
+  height: 18px;
+}
+.form-feedback.success {
+  color: #28a745;
+}
+.form-feedback.error {
+  color: #dc3545;
+}

--- a/data/static/style.css
+++ b/data/static/style.css
@@ -28,6 +28,7 @@ body {
 }
 .content h1 {
   font-size: 24px;
+  margin-top: 20px;
   margin-bottom: 20px;
 }
 .btn {
@@ -60,9 +61,10 @@ body {
   overflow: hidden;
   width: 120px; 
 }
-div label {
+#moduleIntervalForm div label,
+#sensorConfigForm div label {
   display: inline-block;
-  width: 400px; 
+  width: 400px;
 }
 #moduleSwitchForm div label input[type="checkbox"] {
   vertical-align: middle; 
@@ -83,14 +85,13 @@ div label input[type="number"] {
   display: inline-block;
   width: 120px; 
 }
-#wlanSSID, #wlanPASSWORD{
-  width: 200px; 
+#wlanSSID, #wlanPASSWORD {
+  width: 350px;
   padding: 5px;
   font-size: 14px;
   border: 1px solid #ccc;
   border-radius: 4px;
-  box-sizing: border-box; 
-  width: 350px
+  box-sizing: border-box;
 }
 
 .saved-credentials div label, 

--- a/data/static/template.htm
+++ b/data/static/template.htm
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
     <head>
         <meta charset="utf-8">

--- a/data/static/template.htm
+++ b/data/static/template.htm
@@ -1,5 +1,6 @@
 <html>
     <head>
+        <meta charset="utf-8">
         <title>{{deviceName}}</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="stylesheet" href="/static/style.css">

--- a/data/static/wlan.htm
+++ b/data/static/wlan.htm
@@ -2,6 +2,7 @@
 <html>
     <head>
         <title>{{deviceName}} - WLAN Settings</title>
+        <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="stylesheet" href="/static/style.css">
     </head>

--- a/data/static/wlan.htm
+++ b/data/static/wlan.htm
@@ -12,13 +12,6 @@
                 <a href="/index" class="button">Back to Index</a>
             </div>
             <div class="content">
-                <div class="saved-credentials">
-                    <h3>Saved Credentials:</h3>
-                    <div>
-                        <label class="wlanlabel">SSID:</label>
-                        <span>{{ssid}}</span>
-                    </div>
-                </div>
                 <div class="new-credentials">
                     <h3>Enter New Credentials:</h3>
                     <form action="/submitWLANcredentials" method="POST" id="wlanForm">

--- a/data/static/wlan.htm
+++ b/data/static/wlan.htm
@@ -18,19 +18,6 @@
                         <label class="wlanlabel">SSID:</label>
                         <span>{{ssid}}</span>
                     </div>
-                    <div>
-                        <label class="wlanlabel">Password:</label>
-                        <span id="saved-password">********</span>
-                        <button type="button" class="show-password-button" 
-                                onmousedown="toggleSavedPassword(true)" 
-                                onmouseup="toggleSavedPassword(false)" 
-                                onmouseleave="toggleSavedPassword(false)">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" class="bi bi-eye" viewBox="-1 -1 16 16">
-                                  <path d="M16 8s-3-5.5-8-5.5S0 8 0 8s3 5.5 8 5.5S16 8 16 8zM1.173 8a13.133 13.133 0 0 1 1.66-2.043C4.12 4.668 5.88 3.5 8 3.5c2.12 0 3.879 1.168 5.168 2.457A13.133 13.133 0 0 1 14.828 8a13.133 13.133 0 0 1-1.66 2.043C11.879 11.332 10.12 12.5 8 12.5c-2.12 0-3.879-1.168-5.168-2.457A13.133 13.133 0 0 1 1.172 8z"/>
-                                  <path d="M8 5a3 3 0 1 0 0 6 3 3 0 0 0 0-6zM8 6a2 2 0 1 1 0 4 2 2 0 0 1 0-4z"/>
-                              </svg>
-                        </button>
-                    </div>
                 </div>
                 <div class="new-credentials">
                     <h3>Enter New Credentials:</h3>
@@ -61,9 +48,6 @@
         <script>
             function togglePassword(show) {
                 document.getElementById('wlanPASSWORD').type = show ? 'text' : 'password';
-            }
-            function toggleSavedPassword(show) {
-                document.getElementById('saved-password').innerText = show ? '{{password}}' : '********';
             }
         </script>
     </body>

--- a/platformio.ini
+++ b/platformio.ini
@@ -30,7 +30,7 @@ lib_ignore =
 	tiotlab/AsyncTCP
 	zeed/AsyncTCP
 monitor_speed = 9600
-monitor_port = COM4
-upload_port = COM4
+monitor_port = COM3
+upload_port = COM3
 build_flags = -O2
 board_build.filesystem = littlefs

--- a/src/BME680Handler.cpp
+++ b/src/BME680Handler.cpp
@@ -145,7 +145,7 @@ void BME680Handler::printout() const
 	Serial.println("[BME680] run in status:                " + String(bmeSensor.runInStatus));
 	Serial.println("[BME680] gas percentage:               " + String(bmeSensor.gasPercentage));
 	Serial.println("[BME680] temperature [°C]:             " + String(bmeSensor.temperature));
-	Serial.println("[BME680] temperature with offset [°C]: " + String(bmeSensor.temperature + TEMPERATUR_OFFSET));
+	Serial.println("[BME680] temperature with offset [°C]: " + String(bmeSensor.temperature + configHandler.getConfigSensor("tempOffset") / 10.0f));
 	Serial.println("[BME680] raw temperature [°C]:         " + String(bmeSensor.rawTemperature));
 	Serial.println("[BME680] relative humidity [%]:        " + String(bmeSensor.humidity));
 	Serial.println("[BME680] raw relative humidity [%]:    " + String(bmeSensor.rawHumidity));

--- a/src/BME680Handler.cpp
+++ b/src/BME680Handler.cpp
@@ -66,27 +66,29 @@ BME680Handler::BME680Handler()
 
 bool BME680Handler::updateSensorData(const unsigned long currentSeconds)
 {
-
-	if (currentSeconds - _lastRunSeconds >= (unsigned long)configHandler.getConfigInterval("intervalBME680"))
+	// BSEC benötigt regelmäßige Aufrufe alle 3 Sekunden (BSEC_SAMPLE_RATE_LP)
+	// bmeSensor.run() muss daher bei JEDEM Loop-Durchlauf aufgerufen werden
+	// BSEC entscheidet selbst wann neue Daten verfügbar sind
+	
+	bool hasNewData = bmeSensor.run();
+	
+	if (hasNewData)
 	{
-		_lastRunSeconds = currentSeconds;
-		updateState();
-		updateSensorDataInternal();
+		// updateState() nur im konfigurierten Intervall aufrufen
+		// um unnötige EEPROM-Schreibzugriffe zu vermeiden
+		if (currentSeconds - _lastRunSeconds >= (unsigned long)configHandler.getConfigInterval("intervalBME680"))
+		{
+			_lastRunSeconds = currentSeconds;
+			digitalWrite(LED_BUILTIN, HIGH);
+			updateState();
+			digitalWrite(LED_BUILTIN, LOW);
+		}
 		return true;
 	}
+	checkSensorStatus();
 	return false;
 }
 
-void BME680Handler::updateSensorDataInternal()
-{
-	digitalWrite(LED_BUILTIN, HIGH);
-	bool hasNewData = bmeSensor.run();
-	digitalWrite(LED_BUILTIN, LOW);
-	if (!hasNewData)
-	{ 
-		checkSensorStatus();
-	}
-}
 
 void BME680Handler::executeLedError()
 {

--- a/src/BME680Handler.cpp
+++ b/src/BME680Handler.cpp
@@ -1,7 +1,7 @@
 #include "BME680Handler.h"
 #include "Configuration.h"
 #include "ConfigHandler.h"
-extern ConfigHandler configHandler;
+ConfigHandler &configHandler = ConfigHandler::getInstance();
 
 /* Configure the BSEC library with information about the sensor
 		18v/33v = Voltage at Vdd. 1.8V or 3.3V

--- a/src/BME680Handler.cpp
+++ b/src/BME680Handler.cpp
@@ -1,7 +1,7 @@
 #include "BME680Handler.h"
 #include "Configuration.h"
 #include "ConfigHandler.h"
-ConfigHandler &configHandler = ConfigHandler::getInstance();
+extern ConfigHandler &configHandler;
 
 /* Configure the BSEC library with information about the sensor
 		18v/33v = Voltage at Vdd. 1.8V or 3.3V

--- a/src/BME680Handler.cpp
+++ b/src/BME680Handler.cpp
@@ -67,8 +67,9 @@ BME680Handler::BME680Handler()
 bool BME680Handler::updateSensorData(const unsigned long currentSeconds)
 {
 
-	if (currentSeconds % configHandler.getConfigInterval("intervalBME680") == 0)
+	if (currentSeconds - _lastRunSeconds >= (unsigned long)configHandler.getConfigInterval("intervalBME680"))
 	{
+		_lastRunSeconds = currentSeconds;
 		updateState();
 		updateSensorDataInternal();
 		return true;

--- a/src/BME680Handler.h
+++ b/src/BME680Handler.h
@@ -27,5 +27,6 @@ private:
     BME680Handler(BME680Handler const &);
     void operator=(BME680Handler const &); 
     void updateSensorDataInternal();
+    unsigned long _lastRunSeconds = 0;
 };
 #endif // CO2_TURTLE_BME680HANDLER_H

--- a/src/BME680Handler.h
+++ b/src/BME680Handler.h
@@ -26,7 +26,6 @@ private:
     BME680Handler();
     BME680Handler(BME680Handler const &);
     void operator=(BME680Handler const &); 
-    void updateSensorDataInternal();
     unsigned long _lastRunSeconds = 0;
 };
 #endif // CO2_TURTLE_BME680HANDLER_H

--- a/src/ConfigHandler.cpp
+++ b/src/ConfigHandler.cpp
@@ -33,13 +33,13 @@ void ConfigHandler::loadAllPersistedSettings()
 		configMapforDevice["mqttUSER"] = preferences.getString("mqttUSER", MQTT_USER);
 		configMapforDevice["mqttPASSWORD"] = preferences.getString("mqttPASSWORD", MQTT_PASS);
 		configMapforDevice["mqttHOST"] = preferences.getString("mqttHOST", MQTT_HOST);
-		configMapforDevice["mqttPORT"] = preferences.getInt("mqttPORT", MQTT_PORT);
-		configMapforDevice["mqttUSERen"] = preferences.getBool("mqttUSERen", MQTT_USER_ENABLED);
+		configMapforDevice["mqttPORT"] = String(preferences.getInt("mqttPORT", MQTT_PORT));
+		configMapforDevice["mqttUSERen"] = preferences.getBool("mqttUSERen", MQTT_USER_ENABLED) ? "1" : "0";
 
 		configMapforLED["LEDbrightness"] = preferences.getInt("LEDbrightness", BRIGHTNESS_LEDS);
 
 		configMapforSensor["pressure"] = preferences.getInt("pressure", SEALEVELPRESSURE_HPA);
-		configMapforSensor["tempOffset"] = preferences.getInt("tempOffset", TEMPERATUR_OFFSET);
+		configMapforSensor["tempOffset"] = preferences.getInt("tempOffset", (int)(TEMPERATUR_OFFSET * 10));
 	preferences.end();
 }
 
@@ -92,13 +92,13 @@ void ConfigHandler::persistAllSettings()
 	preferences.putBool("switchLED", configMapforSwitch["switchLED"]);
 	preferences.putBool("switchMQTT", configMapforSwitch["switchMQTT"]);
 
-	preferences.putInt("intervalMHZ19", configMapforSwitch["intervalMHZ19"]);
-	preferences.putInt("intervalBME680", configMapforSwitch["intervalBME680"]);
-	preferences.putInt("intervalWiFi", configMapforSwitch["intervalWiFi"]);
-	preferences.putInt("intervalPRINT", configMapforSwitch["intervalPRINT"]);
-	preferences.putInt("intervalEPD", configMapforSwitch["intervalEPD"]);
-	preferences.putInt("intervalLED", configMapforSwitch["intervalLED"]);
-	preferences.putInt("intervalMQTT", configMapforSwitch["intervalMQTT"]);
+	preferences.putInt("intervalMHZ19", configMapforInterval["intervalMHZ19"]);
+	preferences.putInt("intervalBME680", configMapforInterval["intervalBME680"]);
+	preferences.putInt("intervalWiFi", configMapforInterval["intervalWiFi"]);
+	preferences.putInt("intervalPRINT", configMapforInterval["intervalPRINT"]);
+	preferences.putInt("intervalEPD", configMapforInterval["intervalEPD"]);
+	preferences.putInt("intervalLED", configMapforInterval["intervalLED"]);
+	preferences.putInt("intervalMQTT", configMapforInterval["intervalMQTT"]);
 	preferences.end();
 }
 
@@ -133,20 +133,10 @@ void ConfigHandler::restoreDefaultConfiguration()
 	preferences.putBool("mqttUSERen", MQTT_USER_ENABLED);
 
 	preferences.putInt("pressure", SEALEVELPRESSURE_HPA);
-	preferences.putInt("tempOffset", TEMPERATUR_OFFSET);
+	preferences.putInt("tempOffset", (int)(TEMPERATUR_OFFSET * 10));
 
 
-	if (BRIGHTNESS_LEDS > 1 || BRIGHTNESS_LEDS < 256) {
-		preferences.putInt("LEDbrightness", BRIGHTNESS_LEDS);
-	}
-	else {
-		if (BRIGHTNESS_LEDS < 2 ) {
-			preferences.putInt("LEDbrightness", 2);
-		}
-		if ( BRIGHTNESS_LEDS > 255) {
-			preferences.putInt("LEDbrightness", 255);
-		}
-	}
+	preferences.putInt("LEDbrightness", constrain(BRIGHTNESS_LEDS, 2, 255));
 	preferences.end();
 }
 

--- a/src/ConfigHandler.cpp
+++ b/src/ConfigHandler.cpp
@@ -99,6 +99,20 @@ void ConfigHandler::persistAllSettings()
 	preferences.putInt("intervalEPD", configMapforInterval["intervalEPD"]);
 	preferences.putInt("intervalLED", configMapforInterval["intervalLED"]);
 	preferences.putInt("intervalMQTT", configMapforInterval["intervalMQTT"]);
+
+	preferences.putString("deviceName",   configMapforDevice["deviceName"]);
+	preferences.putString("timezone",     configMapforDevice["timezone"]);
+	preferences.putString("wlanSSID",     configMapforDevice["wlanSSID"]);
+	preferences.putString("wlanPASSWORD", configMapforDevice["wlanPASSWORD"]);
+	preferences.putString("mqttUSER",     configMapforDevice["mqttUSER"]);
+	preferences.putString("mqttPASSWORD", configMapforDevice["mqttPASSWORD"]);
+	preferences.putString("mqttHOST",     configMapforDevice["mqttHOST"]);
+
+	preferences.putInt("LEDbrightness", configMapforLED["LEDbrightness"]);
+
+	preferences.putInt("pressure",   configMapforSensor["pressure"]);
+	preferences.putInt("tempOffset", configMapforSensor["tempOffset"]);
+
 	preferences.end();
 }
 

--- a/src/ConfigHandler.h
+++ b/src/ConfigHandler.h
@@ -26,12 +26,12 @@ public:
 	void setConfigSensor(String settingName, int value);
 	void setSettingsOnFirstRun();
 	void validateConfigMaps();
+	void persistAllSettings();
 
 
 private:
 	Preferences preferences;
 	void loadAllPersistedSettings();
-	void persistAllSettings();
 };
 
 #endif

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -21,7 +21,7 @@
 #define SEALEVELPRESSURE_HPA 1015
 #define TEMPERATUR_OFFSET -3.5
 
-#define DeviceName "Turtle 10.05.2025"
+#define DeviceName "Turtle 28.02.2026"
 #define TIMEZONE "CET-1CEST,M3.5.0,M10.5.0/3"
 
 #define PIN_BME680_SDA 21

--- a/src/EPDHandler.cpp
+++ b/src/EPDHandler.cpp
@@ -1,6 +1,5 @@
 #include "EPDHandler.h"
 #include "ConfigHandler.h"
-ConfigHandler &configHandler = ConfigHandler::getInstance();
 #include <GxEPD2_3C.h>
 #include "GxEPD2_display_selection_new_style.h"
 #include "../font/BabelSans8pt7b.h"
@@ -18,6 +17,7 @@ ConfigHandler &configHandler = ConfigHandler::getInstance();
 #include "Configuration.h"
 #include "symbol.h" // own symbol
 
+extern ConfigHandler &configHandler;
 unsigned long EPDHandler::_lastRunSeconds = 0;
 #define EPDPrintFormatBufferSize 5
 

--- a/src/EPDHandler.cpp
+++ b/src/EPDHandler.cpp
@@ -1,6 +1,6 @@
 #include "EPDHandler.h"
 #include "ConfigHandler.h"
-extern ConfigHandler configHandler;
+ConfigHandler &configHandler = ConfigHandler::getInstance();
 #include <GxEPD2_3C.h>
 #include "GxEPD2_display_selection_new_style.h"
 #include "../font/BabelSans8pt7b.h"

--- a/src/EPDHandler.cpp
+++ b/src/EPDHandler.cpp
@@ -18,6 +18,7 @@ extern ConfigHandler configHandler;
 #include "Configuration.h"
 #include "symbol.h" // own symbol
 
+unsigned long EPDHandler::_lastRunSeconds = 0;
 #define EPDPrintFormatBufferSize 5
 
 void EPDHandler::printVertically(const DataCO2 co2, const Bsec bme_data, const String &epd_date, const String &epd_time)
@@ -235,16 +236,18 @@ void EPDHandler::printHorizontally(const DataCO2 co2, const Bsec bme_data, const
 
 void EPDHandler::updateEPDvertical(const DataCO2 co2, const Bsec bme_data, const String &epd_date, const String &epd_time, const unsigned long currentSeconds)
 {
-	if (currentSeconds % configHandler.getConfigInterval("intervalEPD") == 0)
+	if (currentSeconds - _lastRunSeconds >= (unsigned long)configHandler.getConfigInterval("intervalEPD"))
 	{
+		_lastRunSeconds = currentSeconds;
 		printVertically(co2, bme_data, epd_date, epd_time);
 	}
 }
 
 void EPDHandler::updateEPDhorizontal(const DataCO2 co2, const Bsec bme_data, const String &epd_date, const String &epd_time, const unsigned long currentSeconds)
 {
-	if (currentSeconds % configHandler.getConfigInterval("intervalEPD") == 0)
+	if (currentSeconds - _lastRunSeconds >= (unsigned long)configHandler.getConfigInterval("intervalEPD"))
 	{
+		_lastRunSeconds = currentSeconds;
 		printHorizontally(co2, bme_data, epd_date, epd_time);
 	}
 }

--- a/src/EPDHandler.h
+++ b/src/EPDHandler.h
@@ -22,5 +22,6 @@ private:
 	EPDHandler(EPDHandler const &);
 	void operator=(EPDHandler const &);
 	static void PrintEspLine(char *buff, int16_t cursorX, int16_t cursorY, uint16_t color, float toPrint);
+	static unsigned long _lastRunSeconds;
 };
 #endif // CO2_TURTLE_EPDHANDLER_H

--- a/src/LEDHandler.cpp
+++ b/src/LEDHandler.cpp
@@ -2,7 +2,7 @@
 #include "LEDHandler.h"
 #include "LEDsection.h"
 #include "ConfigHandler.h"
-extern ConfigHandler configHandler;
+ConfigHandler &configHandler = ConfigHandler::getInstance();
 
 CRGB leds[NUM_LEDS];
 

--- a/src/LEDHandler.cpp
+++ b/src/LEDHandler.cpp
@@ -2,7 +2,7 @@
 #include "LEDHandler.h"
 #include "LEDsection.h"
 #include "ConfigHandler.h"
-ConfigHandler &configHandler = ConfigHandler::getInstance();
+extern ConfigHandler &configHandler;
 
 CRGB leds[NUM_LEDS];
 

--- a/src/LEDHandler.cpp
+++ b/src/LEDHandler.cpp
@@ -10,7 +10,7 @@ CRGB leds[NUM_LEDS];
 SectionStruc sections[NUM_SECTIONS] = {
 	//{0, 6},	  // LED_TEMP
 	{0, 16},  // LED_HUM
-	{17, 18}, // LED_WLANCONNECT
+	{18, 19}, // LED_WLANCONNECT
 	{21, 37}  // LED_CO2
 };
 

--- a/src/LEDHandler.cpp
+++ b/src/LEDHandler.cpp
@@ -10,7 +10,7 @@ CRGB leds[NUM_LEDS];
 SectionStruc sections[NUM_SECTIONS] = {
 	//{0, 6},	  // LED_TEMP
 	{0, 16},  // LED_HUM
-	{16, 17}, // LED_WLANCONNECT
+	{17, 18}, // LED_WLANCONNECT
 	{21, 37}  // LED_CO2
 };
 

--- a/src/LEDHandler.cpp
+++ b/src/LEDHandler.cpp
@@ -47,8 +47,9 @@ void LEDHandler::setInputDataforLED(DataCO2 co2Sensordata, Bsec enviromentdata)
 
 bool LEDHandler::ledstatus(const unsigned long currentSeconds)
 {
-	if (currentSeconds % configHandler.getConfigInterval("intervalLED")  == 0)
+	if (currentSeconds - _lastRunSeconds >= (unsigned long)configHandler.getConfigInterval("intervalLED"))
 	{
+		_lastRunSeconds = currentSeconds;
 		ledStatusWiFi();
 		ledStatusBME();
 		ledStatusCO2();
@@ -230,8 +231,9 @@ void LEDHandler::ledStatusCO2()
 
 bool LEDHandler::setup_black(const unsigned long currentSeconds)
 {
-	if (currentSeconds % configHandler.getConfigInterval("intervalLED")  == 0)
+	if (currentSeconds - _lastRunSeconds >= (unsigned long)configHandler.getConfigInterval("intervalLED"))
 	{
+		_lastRunSeconds = currentSeconds;
 		FastLED.addLeds<LED_TYPE, DATA_LED_PIN, COLOR_ORDER>(leds, NUM_LEDS);
 		FastLED.clear(true);
 		FastLED.setBrightness(BRIGHTNESS_LEDS);

--- a/src/LEDHandler.h
+++ b/src/LEDHandler.h
@@ -29,11 +29,12 @@ private:
 	void ledStatusWiFi();
 	void ledStatusBME();
 	void ledStatusCO2();
-
+	
 	DataCO2 co2data;
 	Bsec bmedata;
 	LEDHandler() {};					// Constructor? (the {} brackets) are needed here.
 	LEDHandler(LEDHandler const &); // Don't Implement
 	void operator=(LEDHandler const &); // Don't implement
+	unsigned long _lastRunSeconds = 0;
 };
 #endif // CO2_TURTLE_LEDHANDLER_H

--- a/src/MHZ19Handler.cpp
+++ b/src/MHZ19Handler.cpp
@@ -96,6 +96,7 @@ bool MHZ19Handler::updateLastReadout()
 {
 	if (myMHZ19.errorCode == RESULT_OK)
 	{
+		_consecutiveErrors = 0;
 		_lastReadout = DataCO2(
 			myMHZ19.getCO2(),
 			myMHZ19.getCO2Raw(),
@@ -108,17 +109,29 @@ bool MHZ19Handler::updateLastReadout()
 	}
 	else
 	{
-		Serial.println("[MHZ19] Failed to recieve CO2 value - Error");
-		Serial.print("[MHZ19] Response Code: ");
-		Serial.println(myMHZ19.errorCode); // Get the Error Code value
+		_consecutiveErrors++;
+		Serial.printf("[MHZ19] Fehler %d: Response Code %d\n",
+			_consecutiveErrors, myMHZ19.errorCode);
+
+		if (_consecutiveErrors >= 3)
+		{
+			Serial.println("[MHZ19] Recovery: Serial neu initialisieren...");
+			Serial_MHZ19->end();
+			vTaskDelay(500 / portTICK_PERIOD_MS);
+			Serial_MHZ19->begin(BAUDRATE);
+			myMHZ19.begin(*Serial_MHZ19);
+			_consecutiveErrors = 0;
+		}
 		return false;
 	}
 }
 
 bool MHZ19Handler::runUpdate(const unsigned long currentSeconds)
 {
-	if (currentSeconds % configHandler.getConfigInterval("intervalMHZ19") == 0)
+	if (currentSeconds - _lastRunSeconds >=
+		(unsigned long)configHandler.getConfigInterval("intervalMHZ19"))
 	{
+		_lastRunSeconds = currentSeconds;
 		return updateLastReadout();
 	}
 	return false;

--- a/src/MHZ19Handler.cpp
+++ b/src/MHZ19Handler.cpp
@@ -17,8 +17,8 @@ const String name_MHZ19_zone              = "[MHZ19] Timezone";
 
 MHZ19Handler::MHZ19Handler()
 {
-	Serial_MHZ19 = new SoftwareSerial(PIN_MHZ19_RX, PIN_MHZ19_TX);
-	Serial_MHZ19->begin(BAUDRATE); // Uno Example: Begin Stream with MHZ19 baudrate
+	Serial_MHZ19 = &Serial2;
+	Serial2.begin(BAUDRATE, SERIAL_8N1, PIN_MHZ19_RX, PIN_MHZ19_TX); // Uno Example: Begin Stream with MHZ19 baudrate
 	myMHZ19 = MHZ19();
 	myMHZ19.begin(*Serial_MHZ19); // *Important, Pass your Stream reference
 	// myMHZ19.printCommunication();                            // Error Codes are also included here if found (mainly for debugging/interest)
@@ -118,7 +118,7 @@ bool MHZ19Handler::updateLastReadout()
 			Serial.println("[MHZ19] Recovery: Serial neu initialisieren...");
 			Serial_MHZ19->end();
 			vTaskDelay(500 / portTICK_PERIOD_MS);
-			Serial_MHZ19->begin(BAUDRATE);
+			Serial2.begin(BAUDRATE, SERIAL_8N1, PIN_MHZ19_RX, PIN_MHZ19_TX);
 			myMHZ19.begin(*Serial_MHZ19);
 			_consecutiveErrors = 0;
 		}

--- a/src/MHZ19Handler.cpp
+++ b/src/MHZ19Handler.cpp
@@ -1,6 +1,6 @@
 #include "MHZ19Handler.h" //myMHZ19.calibrate();    // Take a reading which be used as the zero point f
 #include "ConfigHandler.h"
-ConfigHandler &configHandler = ConfigHandler::getInstance();
+extern ConfigHandler &configHandler;
 
 const String name_MHZ19_co2               = "[MHZ19] CO2 [ppm]";
 const String name_MHZ19_co2_raw           = "[MHZ19] CO2 raw [ppm]";

--- a/src/MHZ19Handler.cpp
+++ b/src/MHZ19Handler.cpp
@@ -1,6 +1,6 @@
 #include "MHZ19Handler.h" //myMHZ19.calibrate();    // Take a reading which be used as the zero point f
 #include "ConfigHandler.h"
-extern ConfigHandler configHandler;
+ConfigHandler &configHandler = ConfigHandler::getInstance();
 
 const String name_MHZ19_co2               = "[MHZ19] CO2 [ppm]";
 const String name_MHZ19_co2_raw           = "[MHZ19] CO2 raw [ppm]";

--- a/src/MHZ19Handler.h
+++ b/src/MHZ19Handler.h
@@ -1,6 +1,6 @@
 #ifndef CO2_TURTLE_MHZ19HANDLER_H
 #define CO2_TURTLE_MHZ19HANDLER_H
-#include <SoftwareSerial.h>
+#include <HardwareSerial.h>
 #include "MHZ19.h"
 #include "Arduino.h"
 #include "Configuration.h"
@@ -26,7 +26,7 @@ private:
 	bool updateLastReadout();
 	DataCO2 _lastReadout;
 	MHZ19 myMHZ19;
-	SoftwareSerial *Serial_MHZ19;
+	HardwareSerial *Serial_MHZ19;
 	int _consecutiveErrors = 0;
 	unsigned long _lastRunSeconds = 0;
 	MHZ19Handler();						  // Constructor? (the {} brackets) are needed here.

--- a/src/MHZ19Handler.h
+++ b/src/MHZ19Handler.h
@@ -20,11 +20,15 @@ public:
 	bool runUpdate(unsigned long currentSeconds);
 	void calibrate();
 
+
+
 private:
 	bool updateLastReadout();
 	DataCO2 _lastReadout;
 	MHZ19 myMHZ19;
 	SoftwareSerial *Serial_MHZ19;
+	int _consecutiveErrors = 0;
+	unsigned long _lastRunSeconds = 0;
 	MHZ19Handler();						  // Constructor? (the {} brackets) are needed here.
 	MHZ19Handler(MHZ19Handler const &);	  // Don't Implement
 	void operator=(MHZ19Handler const &); // Don't implement

--- a/src/MHZ19Handler.h
+++ b/src/MHZ19Handler.h
@@ -18,9 +18,9 @@ public:
 	void printoutLastReadout();
 	DataCO2 getLastReadout();
 	bool runUpdate(unsigned long currentSeconds);
+	void calibrate();
 
 private:
-	void calibrate();
 	bool updateLastReadout();
 	DataCO2 _lastReadout;
 	MHZ19 myMHZ19;

--- a/src/MqttClientHandler.cpp
+++ b/src/MqttClientHandler.cpp
@@ -3,6 +3,7 @@
 #include "Credentials.h"
 #include <WiFi.h>
 #include "ConfigHandler.h"
+unsigned long MqttClientHandler::_lastRunSeconds = 0;
 extern ConfigHandler configHandler;
 
 extern "C"
@@ -62,8 +63,9 @@ void MqttClientHandler::setup_Mqtt()
 
 void MqttClientHandler::publishData(const DataCO2 data_co2, const Bsec data_bme, const unsigned long currentSeconds)
 {
-	if (currentSeconds % configHandler.getConfigInterval("intervalMQTT") == 0)
+	if (currentSeconds - _lastRunSeconds >= (unsigned long)configHandler.getConfigInterval("intervalMQTT"))
 	{
+		_lastRunSeconds = currentSeconds;
 		connectToMqtt();
 		if (mqttClient.connected() == false)
 		{

--- a/src/MqttClientHandler.cpp
+++ b/src/MqttClientHandler.cpp
@@ -68,7 +68,7 @@ void MqttClientHandler::publishData(const DataCO2 data_co2, const Bsec data_bme,
 		if (mqttClient.connected() == false)
 		{
 			mqttClient.publish("sensor/bme680/temperature", 1, true, String(data_bme.temperature).c_str());
-			mqttClient.publish("sensor/bme680/temperature_offset", 1, true, String(data_bme.temperature + TEMPERATUR_OFFSET).c_str());
+			mqttClient.publish("sensor/bme680/temperature_offset", 1, true, String(data_bme.temperature + configHandler.getConfigSensor("tempOffset") / 10.0f).c_str());
 			mqttClient.publish("sensor/bme680/temperature_raw", 1, true, String(data_bme.rawTemperature).c_str());
 			mqttClient.publish("sensor/bme680/humidity", 1, true, String(data_bme.humidity).c_str());
 			mqttClient.publish("sensor/bme680/humidity_raw", 1, true, String(data_bme.rawHumidity).c_str());

--- a/src/MqttClientHandler.cpp
+++ b/src/MqttClientHandler.cpp
@@ -4,7 +4,7 @@
 #include <WiFi.h>
 #include "ConfigHandler.h"
 unsigned long MqttClientHandler::_lastRunSeconds = 0;
-ConfigHandler &configHandler = ConfigHandler::getInstance();
+extern ConfigHandler &configHandler;
 
 extern "C"
 {

--- a/src/MqttClientHandler.cpp
+++ b/src/MqttClientHandler.cpp
@@ -4,7 +4,7 @@
 #include <WiFi.h>
 #include "ConfigHandler.h"
 unsigned long MqttClientHandler::_lastRunSeconds = 0;
-extern ConfigHandler configHandler;
+ConfigHandler &configHandler = ConfigHandler::getInstance();
 
 extern "C"
 {

--- a/src/MqttClientHandler.h
+++ b/src/MqttClientHandler.h
@@ -24,5 +24,6 @@ private:
 	static void connectToMqtt();
 	static void disconnectfromMqtt();
 	static void onMqttDisconnect(AsyncMqttClientDisconnectReason reason);
+	static unsigned long _lastRunSeconds;
 };
 #endif // CO2_TURTLE_MQTTCLIENTHANDLER_H

--- a/src/WebServerHandler.cpp
+++ b/src/WebServerHandler.cpp
@@ -195,7 +195,6 @@ void WebServerHandler::handle_page_wlan(AsyncWebServerRequest *request)
 	file.close();
 
 	content.replace("{{deviceName}}", DeviceName);
-	content.replace("{{ssid}}", String(ssid));
 	request->send(200, "text/html", content);
 }
 

--- a/src/WebServerHandler.cpp
+++ b/src/WebServerHandler.cpp
@@ -196,8 +196,6 @@ void WebServerHandler::handle_page_wlan(AsyncWebServerRequest *request)
 
 	content.replace("{{deviceName}}", DeviceName);
 	content.replace("{{ssid}}", String(ssid));
-	content.replace("{{password}}", String(password));
-
 	request->send(200, "text/html", content);
 }
 

--- a/src/WebServerHandler.cpp
+++ b/src/WebServerHandler.cpp
@@ -17,15 +17,16 @@ void WebServerHandler::start()
     server.on("/index", HTTP_GET, [this](AsyncWebServerRequest *request) {handle_page_index(request);});
 	server.on("/json", HTTP_GET, [this](AsyncWebServerRequest *request) {handle_page_data(request); });
 	server.on("/status", HTTP_GET, [this](AsyncWebServerRequest *request) {handle_page_status(request); });
-	server.on("/sensorsettings", HTTP_GET, [this](AsyncWebServerRequest *request) {handle_page_sensorsettings(request); });
+	server.on("/settings", HTTP_GET, [this](AsyncWebServerRequest *request) {handle_page_settings(request); });
 	server.on("/WLAN", HTTP_GET, [this](AsyncWebServerRequest *request) {handle_page_wlan(request); });
 	server.on("/submitWLANcredentials", HTTP_POST, [this](AsyncWebServerRequest *request) {handle_submit_WLANcredentials(request); });
 	server.on("/submitmodulinterval", HTTP_POST, [this](AsyncWebServerRequest *request) {handle_submit_modulinterval(request); });
 	server.on("/submitmodulswitch", HTTP_POST, [this](AsyncWebServerRequest *request) {handle_submit_modulswitch(request); });
 	server.on("/submitLEDConfig", HTTP_POST, [this](AsyncWebServerRequest *request) {handle_submit_ledconfig(request); });
-	server.on("/restoredefaultconfiguration", HTTP_POST, [this](AsyncWebServerRequest *request) {handle_restoreDefaultConfiguration(request); });
-	server.on("/restart", HTTP_POST, [this](AsyncWebServerRequest *request) {handle_restart(request); });
-	server.on("/calibrateMHZ19", HTTP_POST, [this](AsyncWebServerRequest *request) { handle_calibrate_mhz19(request); });
+	server.on("/submitSensorConfig", HTTP_POST, [this](AsyncWebServerRequest *request) { handle_submit_sensorconfig(request); });
+	server.on("/restoredefaultconfiguration", HTTP_POST, [this](AsyncWebServerRequest *request) {handle_option_restoreDefaultConfiguration(request); });
+	server.on("/restart", HTTP_POST, [this](AsyncWebServerRequest *request) {handle_option_restart(request); });
+	server.on("/calibrateMHZ19", HTTP_POST, [this](AsyncWebServerRequest *request) { handle_option_calibrate_mhz19(request); });
 	server.onNotFound(handle_page_NotFound);
 	server.begin();
 }
@@ -192,12 +193,12 @@ void WebServerHandler::handle_page_wlan(AsyncWebServerRequest *request)
 	request->send(200, "text/html", content);
 }
 
-void WebServerHandler::handle_page_sensorsettings(AsyncWebServerRequest *request)
+void WebServerHandler::handle_page_settings(AsyncWebServerRequest *request)
 {
-	File file = LittleFS.open("/static/setting.htm", "r");
+	File file = LittleFS.open("/static/settings.htm", "r");
 	if (!file || file.isDirectory())
 	{
-		request->send(500, "text/plain", "Internal Server Error: Cannot open setting.htm");
+		request->send(500, "text/plain", "Internal Server Error: Cannot open settings.htm");
 		return;
 	}
 	String content = file.readString();
@@ -218,9 +219,17 @@ void WebServerHandler::handle_page_sensorsettings(AsyncWebServerRequest *request
 	content.replace("{{switchMQTT_checked}}", configHandler.getConfigSwitch("switchMQTT") ? "checked" : "");
 
 	content.replace("{{LEDbrightness}}", String(configHandler.getConfigLED("LEDbrightness")));
+	content.replace("{{SEALEVELPRESSURE_HPA}}", String(configHandler.getConfigSensor("pressure")));
+	content.replace("{{TEMPERATUR_OFFSET}}", String(configHandler.getConfigSensor("tempOffset")));
 
 	request->send(200, "text/html; charset=utf-8", content);
 }
+
+void WebServerHandler::handle_page_NotFound(AsyncWebServerRequest *request)
+{
+	request->send(404, "text/plain", "404: Not found");
+}
+
 
 void WebServerHandler::handle_submit_WLANcredentials(AsyncWebServerRequest *request)
 {
@@ -237,11 +246,6 @@ void WebServerHandler::handle_submit_WLANcredentials(AsyncWebServerRequest *requ
 	request->send(200, "text/plain", "WLAN Settings Saved!");
 	request->redirect("/index");
 	ESP.restart();
-}
-
-void WebServerHandler::handle_page_NotFound(AsyncWebServerRequest *request)
-{
-	request->send(404, "text/plain", "404: Not found");
 }
 
 void WebServerHandler::handle_submit_modulinterval(AsyncWebServerRequest *request)
@@ -318,7 +322,7 @@ void WebServerHandler::handle_submit_modulinterval(AsyncWebServerRequest *reques
 		configHandler.setConfigInterval("intervalMQTT", interval_mqtt_in_Seconds);
 	}
 	request->send(200, "text/plain", "Interval Settings Saved!");
-	request->redirect("/sensorsettings");
+	request->redirect("/settings");
 }
 
 void WebServerHandler::handle_submit_modulswitch(AsyncWebServerRequest *request)
@@ -340,7 +344,7 @@ void WebServerHandler::handle_submit_modulswitch(AsyncWebServerRequest *request)
 		configHandler.setConfigSwitch("switchMQTT", atoi(request->getParam("switchMQTT")->value().c_str()));
 	} 
 	request->send(200, "text/plain", "Modul Settings Saved!");
-	request->redirect("/sensorsettings");
+	request->redirect("/settings");
 }
 
 void WebServerHandler::handle_submit_ledconfig(AsyncWebServerRequest *request)
@@ -359,35 +363,71 @@ void WebServerHandler::handle_submit_ledconfig(AsyncWebServerRequest *request)
         return;
     }
     request->send(200, "text/plain", "LED Settings Saved!");
-    request->redirect("/sensorsettings");
+    request->redirect("/settings");
 }
 
-void WebServerHandler::handle_restoreDefaultConfiguration(AsyncWebServerRequest *request)
+void WebServerHandler::handle_submit_sensorconfig(AsyncWebServerRequest *request)
 {
-	configHandler.restoreDefaultConfiguration(); 
-	request->redirect("/index");
-	delay(1000);
-	request->send(200, "text/plain", "Defaults loaded");
-	delay(500);
-	ESP.restart();
+    bool updated = false;
+
+    if (request->hasParam("SEALEVELPRESSURE_HPA", true)) {
+        int sealevel = request->getParam("SEALEVELPRESSURE_HPA", true)->value().toInt();
+        configHandler.setConfigSensor("pressure", sealevel);
+        updated = true;
+    }
+    if (request->hasParam("TEMPERATUR_OFFSET", true)) {
+        float tempOffset = request->getParam("TEMPERATUR_OFFSET", true)->value().toFloat();
+        configHandler.setConfigSensor("tempOffset", tempOffset);
+        updated = true;
+    }
+
+    if (updated) {
+        request->send(200, "text/plain", "Sensor configuration saved!");
+    } else {
+        request->send(400, "text/plain", "Bad Request: Missing parameters");
+    }
 }
 
-void WebServerHandler::handle_restart(AsyncWebServerRequest *request)
+
+void WebServerHandler::handle_option_restoreDefaultConfiguration(AsyncWebServerRequest *request)
 {
-	request->send(200, "text/html", "Device is restarting...");
-	delay(1000);
-	request->redirect("/index");
-	delay(500);
-	ESP.restart();
+	request->send(200, "text/html",
+    "<html><head>"
+    "<meta http-equiv='refresh' content='6;url=/'>"
+    "</head><body style='font-family:sans-serif;padding:40px'>"
+    "<h2>Standardkonfiguration geladen.</h2>"
+    "<p>Weiterleitung in 6 Sekunden.</p>"
+    "</body></html>");
+
+	xTaskCreate([](void*) {
+		vTaskDelay(1500 / portTICK_PERIOD_MS);
+		ESP.restart();
+	}, "restore_task", 1024, nullptr, 1, nullptr);
 }
 
-void WebServerHandler::handle_calibrate_mhz19(AsyncWebServerRequest *request)
+void WebServerHandler::handle_option_restart(AsyncWebServerRequest *request)
+{
+	    request->send(200, "text/html",
+        "<html><head>"
+        "<meta http-equiv='refresh' content='6;url=/'>"
+        "</head><body style='font-family:sans-serif;padding:40px'>"
+        "<h2>Neustart läuft...</h2>"
+        "<p>Weiterleitung in 6 Sekunden.</p>"
+        "</body></html>");
+
+    xTaskCreate([](void*) {
+        vTaskDelay(1500 / portTICK_PERIOD_MS);
+        ESP.restart();
+    }, "restart_task", 1024, nullptr, 1, nullptr);
+}
+
+void WebServerHandler::handle_option_calibrate_mhz19(AsyncWebServerRequest *request)
 {
     MHZ19Handler &mhz19Handler = MHZ19Handler::getInstance();
     mhz19Handler.calibrate();
     request->send(200, "text/plain", "Calibration started.");
 	delay(1000);
-	request->redirect("/sensorsettings");
+	request->redirect("/settings");
 }
 
 // --------------------

--- a/src/WebServerHandler.cpp
+++ b/src/WebServerHandler.cpp
@@ -2,6 +2,7 @@
 #include "Configuration.h"
 #include "Credentials.h"
 #include <LittleFS.h>
+#include "MHZ19Handler.h"
 #include "ConfigHandler.h"
 extern ConfigHandler configHandler;
 #include "LEDHandler.h"
@@ -24,6 +25,7 @@ void WebServerHandler::start()
 	server.on("/submitLEDConfig", HTTP_POST, [this](AsyncWebServerRequest *request) {handle_submit_ledconfig(request); });
 	server.on("/restoredefaultconfiguration", HTTP_POST, [this](AsyncWebServerRequest *request) {handle_restoreDefaultConfiguration(request); });
 	server.on("/restart", HTTP_POST, [this](AsyncWebServerRequest *request) {handle_restart(request); });
+	server.on("/calibrateMHZ19", HTTP_POST, [this](AsyncWebServerRequest *request) { handle_calibrate_mhz19(request); });
 	server.onNotFound(handle_page_NotFound);
 	server.begin();
 }
@@ -379,6 +381,14 @@ void WebServerHandler::handle_restart(AsyncWebServerRequest *request)
 	ESP.restart();
 }
 
+void WebServerHandler::handle_calibrate_mhz19(AsyncWebServerRequest *request)
+{
+    MHZ19Handler &mhz19Handler = MHZ19Handler::getInstance();
+    mhz19Handler.calibrate();
+    request->send(200, "text/plain", "Calibration started.");
+	delay(1000);
+	request->redirect("/sensorsettings");
+}
 
 // --------------------
 // Helpers

--- a/src/WebServerHandler.cpp
+++ b/src/WebServerHandler.cpp
@@ -137,7 +137,7 @@ void WebServerHandler::handle_page_status(AsyncWebServerRequest *request)
 	header_data.replace("{{data_breahtvoc}}", String(bmedata.breathVocEquivalent));
 	header_data.replace("{{data_pressure}}", String(bmedata.pressure/100));
 	header_data.replace("{{data_timestep}}", String(bmedata.outputTimestamp));
-	header_data.replace("{{data_zone}}", TIMEZONE);
+	header_data.replace("{{data_zone}}", configHandler.getConfigDevice("timezone"));
 	header_data.replace("{{data_time}}", acDate);
 
 	// Sensor Accuracy
@@ -220,7 +220,7 @@ void WebServerHandler::handle_page_settings(AsyncWebServerRequest *request)
 
 	content.replace("{{LEDbrightness}}", String(configHandler.getConfigLED("LEDbrightness")));
 	content.replace("{{SEALEVELPRESSURE_HPA}}", String(configHandler.getConfigSensor("pressure")));
-	content.replace("{{TEMPERATUR_OFFSET}}", String(configHandler.getConfigSensor("tempOffset")));
+	content.replace("{{TEMPERATUR_OFFSET}}", String(configHandler.getConfigSensor("tempOffset") / 10.0f));
 
 	request->send(200, "text/html; charset=utf-8", content);
 }
@@ -330,6 +330,7 @@ void WebServerHandler::handle_submit_modulinterval(AsyncWebServerRequest *reques
 		Serial.println("MQTT Interval not set. Using default value.");
 		configHandler.setConfigInterval("intervalMQTT", interval_mqtt_in_Seconds);
 	}
+	configHandler.persistAllSettings();
 	request->send(200, "text/plain", "Interval Settings Saved!");
 	request->redirect("/settings");
 }
@@ -352,6 +353,7 @@ void WebServerHandler::handle_submit_modulswitch(AsyncWebServerRequest *request)
 	{
 		configHandler.setConfigSwitch("switchMQTT", atoi(request->getParam("switchMQTT")->value().c_str()));
 	} 
+	configHandler.persistAllSettings();
 	request->send(200, "text/plain", "Modul Settings Saved!");
 	request->redirect("/settings");
 }
@@ -371,6 +373,7 @@ void WebServerHandler::handle_submit_ledconfig(AsyncWebServerRequest *request)
         request->send(400, "text/plain", "Bad Request: Missing parameters");
         return;
     }
+	configHandler.persistAllSettings();
     request->send(200, "text/plain", "LED Settings Saved!");
     request->redirect("/settings");
 }
@@ -391,6 +394,7 @@ void WebServerHandler::handle_submit_sensorconfig(AsyncWebServerRequest *request
     }
 
     if (updated) {
+		configHandler.persistAllSettings();
         request->send(200, "text/plain", "Sensor configuration saved!");
     } else {
         request->send(400, "text/plain", "Bad Request: Missing parameters");

--- a/src/WebServerHandler.cpp
+++ b/src/WebServerHandler.cpp
@@ -12,8 +12,15 @@ WebServerHandler::WebServerHandler()
 
 void WebServerHandler::start()
 {
-	DefaultHeaders::Instance().addHeader("Content-Encoding", "identity");
-	server.serveStatic("/static", LittleFS, "/static").setDefaultFile("index.htm").setCacheControl("no-cache");
+	//load files directly without triggering gz error in console
+	server.on("/static/style.css", HTTP_GET, [](AsyncWebServerRequest *request) {request->send(LittleFS, "/static/style.css", "text/css");});
+	server.on("/static/index.htm", HTTP_GET, [](AsyncWebServerRequest *request) {request->send(LittleFS, "/static/index.htm", "text/html");});
+	server.on("/static/status.htm", HTTP_GET, [](AsyncWebServerRequest *request) {request->send(LittleFS, "/static/status.htm", "text/html");});
+	server.on("/static/settings.htm", HTTP_GET, [](AsyncWebServerRequest *request) {request->send(LittleFS, "/static/settings.htm", "text/html");});
+	server.on("/static/wlan.htm", HTTP_GET, [](AsyncWebServerRequest *request) {request->send(LittleFS, "/static/wlan.htm", "text/html");});
+	server.on("/static/template.htm", HTTP_GET, [](AsyncWebServerRequest *request) {request->send(LittleFS, "/static/template.htm", "text/html");});
+
+	// webserver linking
     server.on("/", HTTP_GET, [this](AsyncWebServerRequest *request) {request->redirect("/index"); });
     server.on("/index", HTTP_GET, [this](AsyncWebServerRequest *request) {handle_page_index(request);});
 	server.on("/json", HTTP_GET, [this](AsyncWebServerRequest *request) {handle_page_data(request); });

--- a/src/WebServerHandler.cpp
+++ b/src/WebServerHandler.cpp
@@ -243,9 +243,18 @@ void WebServerHandler::handle_submit_WLANcredentials(AsyncWebServerRequest *requ
 		request->send(400, "text/plain", "Bad Request: Missing parameters");
 		return;
 	}
-	request->send(200, "text/plain", "WLAN Settings Saved!");
-	request->redirect("/index");
-	ESP.restart();
+	request->send(200, "text/html",
+    "<html><head>"
+    "<meta http-equiv='refresh' content='6;url=/'>"
+    "</head><body style='font-family:sans-serif;padding:40px'>"
+    "<h2>WLAN Einstellungen gespeichert.</h2>"
+    "<p>Weiterleitung in 6 Sekunden.</p>"
+    "</body></html>");
+
+	xTaskCreate([](void*) {
+		vTaskDelay(1500 / portTICK_PERIOD_MS);
+		ESP.restart();
+	}, "wlan_restart_task", 1024, nullptr, 1, nullptr);
 }
 
 void WebServerHandler::handle_submit_modulinterval(AsyncWebServerRequest *request)

--- a/src/WebServerHandler.cpp
+++ b/src/WebServerHandler.cpp
@@ -12,12 +12,13 @@ WebServerHandler::WebServerHandler()
 
 void WebServerHandler::start()
 {
-    server.serveStatic("/static", LittleFS, "/static").setDefaultFile("index.htm");
+	DefaultHeaders::Instance().addHeader("Content-Encoding", "identity");
+    server.serveStatic("/static", LittleFS, "/static").setDefaultFile("index.htm").setCacheControl("no-cache");
     server.on("/", HTTP_GET, [this](AsyncWebServerRequest *request) {request->redirect("/index"); });
     server.on("/index", HTTP_GET, [this](AsyncWebServerRequest *request) {handle_page_index(request);});
 	server.on("/json", HTTP_GET, [this](AsyncWebServerRequest *request) {handle_page_data(request); });
 	server.on("/status", HTTP_GET, [this](AsyncWebServerRequest *request) {handle_page_status(request); });
-	server.on("/settings", HTTP_GET, [this](AsyncWebServerRequest *request) {handle_page_settings(request); });
+	server.on("/sensorsettings", HTTP_GET, [this](AsyncWebServerRequest *request) {handle_page_settings(request); });
 	server.on("/WLAN", HTTP_GET, [this](AsyncWebServerRequest *request) {handle_page_wlan(request); });
 	server.on("/submitWLANcredentials", HTTP_POST, [this](AsyncWebServerRequest *request) {handle_submit_WLANcredentials(request); });
 	server.on("/submitmodulinterval", HTTP_POST, [this](AsyncWebServerRequest *request) {handle_submit_modulinterval(request); });
@@ -332,7 +333,7 @@ void WebServerHandler::handle_submit_modulinterval(AsyncWebServerRequest *reques
 	}
 	configHandler.persistAllSettings();
 	request->send(200, "text/plain", "Interval Settings Saved!");
-	request->redirect("/settings");
+	request->redirect("/sensorsettings");
 }
 
 void WebServerHandler::handle_submit_modulswitch(AsyncWebServerRequest *request)
@@ -355,7 +356,7 @@ void WebServerHandler::handle_submit_modulswitch(AsyncWebServerRequest *request)
 	} 
 	configHandler.persistAllSettings();
 	request->send(200, "text/plain", "Modul Settings Saved!");
-	request->redirect("/settings");
+	request->redirect("/sensorsettings");
 }
 
 void WebServerHandler::handle_submit_ledconfig(AsyncWebServerRequest *request)
@@ -375,7 +376,7 @@ void WebServerHandler::handle_submit_ledconfig(AsyncWebServerRequest *request)
     }
 	configHandler.persistAllSettings();
     request->send(200, "text/plain", "LED Settings Saved!");
-    request->redirect("/settings");
+    request->redirect("/sensorsettings");
 }
 
 void WebServerHandler::handle_submit_sensorconfig(AsyncWebServerRequest *request)
@@ -440,7 +441,7 @@ void WebServerHandler::handle_option_calibrate_mhz19(AsyncWebServerRequest *requ
     mhz19Handler.calibrate();
     request->send(200, "text/plain", "Calibration started.");
 	delay(1000);
-	request->redirect("/settings");
+	request->redirect("/sensorsettings");
 }
 
 // --------------------

--- a/src/WebServerHandler.cpp
+++ b/src/WebServerHandler.cpp
@@ -4,8 +4,8 @@
 #include <LittleFS.h>
 #include "MHZ19Handler.h"
 #include "ConfigHandler.h"
-ConfigHandler &configHandler = ConfigHandler::getInstance();
 #include "LEDHandler.h"
+extern ConfigHandler &configHandler;
 
 WebServerHandler::WebServerHandler()
 	: server(80) {}

--- a/src/WebServerHandler.cpp
+++ b/src/WebServerHandler.cpp
@@ -92,7 +92,7 @@ void WebServerHandler::handle_page_data(AsyncWebServerRequest *request)
 	headerData.replace("{{nextCall}}", String(bmedata.nextCall));
 	headerData.replace("{{outputTimestamp}}", String(bmedata.outputTimestamp));
 	headerData.replace("{{temperature}}", String(bmedata.temperature));
-	headerData.replace("{{temperature_offset}}", String(bmedata.temperature + TEMPERATUR_OFFSET));
+	headerData.replace("{{temperature_offset}}", String(bmedata.temperature + configHandler.getConfigSensor("tempOffset") / 10.0f));
 	headerData.replace("{{temperature_raw}}", String(bmedata.rawTemperature));
 	headerData.replace("{{humidity}}", String(bmedata.humidity));
 	headerData.replace("{{humidity_raw}}", String(bmedata.rawHumidity));
@@ -377,7 +377,7 @@ void WebServerHandler::handle_submit_sensorconfig(AsyncWebServerRequest *request
     }
     if (request->hasParam("TEMPERATUR_OFFSET", true)) {
         float tempOffset = request->getParam("TEMPERATUR_OFFSET", true)->value().toFloat();
-        configHandler.setConfigSensor("tempOffset", tempOffset);
+        configHandler.setConfigSensor("tempOffset", (int)(tempOffset * 10));
         updated = true;
     }
 

--- a/src/WebServerHandler.cpp
+++ b/src/WebServerHandler.cpp
@@ -13,7 +13,7 @@ WebServerHandler::WebServerHandler()
 void WebServerHandler::start()
 {
 	DefaultHeaders::Instance().addHeader("Content-Encoding", "identity");
-    server.serveStatic("/static", LittleFS, "/static").setDefaultFile("index.htm").setCacheControl("no-cache");
+	server.serveStatic("/static", LittleFS, "/static").setDefaultFile("index.htm").setCacheControl("no-cache");
     server.on("/", HTTP_GET, [this](AsyncWebServerRequest *request) {request->redirect("/index"); });
     server.on("/index", HTTP_GET, [this](AsyncWebServerRequest *request) {handle_page_index(request);});
 	server.on("/json", HTTP_GET, [this](AsyncWebServerRequest *request) {handle_page_data(request); });

--- a/src/WebServerHandler.cpp
+++ b/src/WebServerHandler.cpp
@@ -4,7 +4,7 @@
 #include <LittleFS.h>
 #include "MHZ19Handler.h"
 #include "ConfigHandler.h"
-extern ConfigHandler configHandler;
+ConfigHandler &configHandler = ConfigHandler::getInstance();
 #include "LEDHandler.h"
 
 WebServerHandler::WebServerHandler()

--- a/src/WebServerHandler.cpp
+++ b/src/WebServerHandler.cpp
@@ -12,7 +12,7 @@ WebServerHandler::WebServerHandler()
 
 void WebServerHandler::start()
 {
-    server.serveStatic("/static", LittleFS, "/static");
+    server.serveStatic("/static", LittleFS, "/static").setDefaultFile("index.htm");
     server.on("/", HTTP_GET, [this](AsyncWebServerRequest *request) {request->redirect("/index"); });
     server.on("/index", HTTP_GET, [this](AsyncWebServerRequest *request) {handle_page_index(request);});
 	server.on("/json", HTTP_GET, [this](AsyncWebServerRequest *request) {handle_page_data(request); });

--- a/src/WebServerHandler.h
+++ b/src/WebServerHandler.h
@@ -42,6 +42,8 @@ private:
 	void handle_submit_ledconfig(AsyncWebServerRequest *request);
 	void handle_restoreDefaultConfiguration(AsyncWebServerRequest *request);
 	void handle_restart(AsyncWebServerRequest *request);
+	void handle_calibrate_mhz19(AsyncWebServerRequest *request);
+
 
 	// helper function
 	void replaceColorDescr(String &str, const String &key, const String &color, const String &descr);

--- a/src/WebServerHandler.h
+++ b/src/WebServerHandler.h
@@ -33,16 +33,17 @@ private:
 	static void handle_page_index(AsyncWebServerRequest *request);
 	void handle_page_data(AsyncWebServerRequest *request);
 	void handle_page_status(AsyncWebServerRequest *request);
-	void handle_page_sensorsettings(AsyncWebServerRequest *request);
+	void handle_page_settings(AsyncWebServerRequest *request);
 	void handle_page_wlan(AsyncWebServerRequest *request);
 	static void handle_page_NotFound(AsyncWebServerRequest *request);
 	void handle_submit_WLANcredentials(AsyncWebServerRequest *request);
 	void handle_submit_modulinterval(AsyncWebServerRequest *request);
 	void handle_submit_modulswitch(AsyncWebServerRequest *request);
 	void handle_submit_ledconfig(AsyncWebServerRequest *request);
-	void handle_restoreDefaultConfiguration(AsyncWebServerRequest *request);
-	void handle_restart(AsyncWebServerRequest *request);
-	void handle_calibrate_mhz19(AsyncWebServerRequest *request);
+	void handle_submit_sensorconfig(AsyncWebServerRequest *request);
+	void handle_option_restoreDefaultConfiguration(AsyncWebServerRequest *request);
+	void handle_option_restart(AsyncWebServerRequest *request);
+	void handle_option_calibrate_mhz19(AsyncWebServerRequest *request);
 
 
 	// helper function

--- a/src/WiFiHandler.cpp
+++ b/src/WiFiHandler.cpp
@@ -4,6 +4,7 @@
 #include "Credentials.h"
 #include "Configuration.h"
 #include "ConfigHandler.h"
+unsigned long WiFiHandler::_lastRunSeconds = 0;
 extern ConfigHandler configHandler;
 String password;
 String ssid;
@@ -92,8 +93,9 @@ bool WiFiHandler::StatusCheck()
 
 bool WiFiHandler::checkWifiStatus(unsigned long currentSeconds)
 {
-	if (currentSeconds % configHandler.getConfigInterval("intervalWiFi") == 0)
+	if (currentSeconds - _lastRunSeconds >= (unsigned long)configHandler.getConfigInterval("intervalWiFi"))
 	{
+		_lastRunSeconds = currentSeconds;
 		return WiFiHandler::StatusCheck();
 	}
 	return false;

--- a/src/WiFiHandler.cpp
+++ b/src/WiFiHandler.cpp
@@ -31,9 +31,13 @@ void WiFiHandler::setupAPMode()
 void WiFiHandler::initWifi()
 {
 	int wifiWaitCount = 0;
+	// set device for mDNS and hostname
 	String hostname = configHandler.getConfigDevice("deviceName");
-	hostname.replace(" ", "-");  // spaces are not allowed
-	WiFiClass::setHostname(hostname.c_str());
+	hostname.replace(" ", "-");
+	hostname.toLowerCase();
+	WiFi.setHostname(hostname.c_str());
+	WiFi.setAutoReconnect(true);
+	WiFi.persistent(true);
 #ifdef DEBUG
 	Serial.print("\n[WIFI] Connecting to ");
 	Serial.println(WIFI_SSID);
@@ -73,6 +77,8 @@ void WiFiHandler::ReStart()
 	Serial.println(WIFI_SSID);
 #endif
 	loadWiFiCredentials();
+	WiFi.disconnect(true);
+	delay(100);
 	WiFi.begin(ssid.c_str(), password.c_str());
 	int wifiWaitCount = 0;
 	while (WiFiClass::status() != WL_CONNECTED && wifiWaitCount < 20)

--- a/src/WiFiHandler.cpp
+++ b/src/WiFiHandler.cpp
@@ -5,7 +5,7 @@
 #include "Configuration.h"
 #include "ConfigHandler.h"
 unsigned long WiFiHandler::_lastRunSeconds = 0;
-extern ConfigHandler configHandler;
+ConfigHandler &configHandler = ConfigHandler::getInstance();
 String password;
 String ssid;
 

--- a/src/WiFiHandler.cpp
+++ b/src/WiFiHandler.cpp
@@ -1,5 +1,6 @@
 #include <WiFi.h>
 #include "WiFiHandler.h"
+#include "mdns.h"
 // please rename credentials_example.h to credentials.h and set your WIFI Credentials there
 #include "Credentials.h"
 #include "Configuration.h"
@@ -30,7 +31,9 @@ void WiFiHandler::setupAPMode()
 void WiFiHandler::initWifi()
 {
 	int wifiWaitCount = 0;
-	WiFiClass::setHostname(DeviceName);
+	String hostname = configHandler.getConfigDevice("deviceName");
+	hostname.replace(" ", "-");  // spaces are not allowed
+	WiFiClass::setHostname(hostname.c_str());
 #ifdef DEBUG
 	Serial.print("\n[WIFI] Connecting to ");
 	Serial.println(WIFI_SSID);
@@ -47,6 +50,13 @@ void WiFiHandler::initWifi()
 	{
 		Serial.print("[WIFI] connected. IP address: ");
 		Serial.println(WiFi.localIP());
+		String mdnsName = configHandler.getConfigDevice("deviceName");
+		mdnsName.replace(" ", "-");
+		if (mdns_init() == ESP_OK)
+		{
+			mdns_hostname_set(mdnsName.c_str());
+			Serial.println("[WIFI] mDNS gestartet: http://" + mdnsName + ".local");
+		}
 	}
 	else
 	{

--- a/src/WiFiHandler.cpp
+++ b/src/WiFiHandler.cpp
@@ -4,8 +4,8 @@
 #include "Credentials.h"
 #include "Configuration.h"
 #include "ConfigHandler.h"
+extern ConfigHandler &configHandler;
 unsigned long WiFiHandler::_lastRunSeconds = 0;
-ConfigHandler &configHandler = ConfigHandler::getInstance();
 String password;
 String ssid;
 

--- a/src/WiFiHandler.h
+++ b/src/WiFiHandler.h
@@ -12,6 +12,7 @@ private:
 	static bool StatusCheck();
 	static void ReStart();
 	static void loadWiFiCredentials();
+	static unsigned long _lastRunSeconds;
 };
 
 #endif // CO2_TURTLE_WIFIHANDLER_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,6 +49,7 @@
 #include "MqttClientHandler.h"
 #include "ConfigHandler.h"
 #include <LittleFS.h>
+ConfigHandler &configHandler = ConfigHandler::getInstance();
 
 // --------------------------------------------------------------------------
 // time functions
@@ -81,7 +82,6 @@ String localTime(const String &format)
 #ifdef DEBUG
 static void PrintRamUsage(unsigned long currentSeconds)
 {
-	ConfigHandler &configHandler = ConfigHandler::getInstance();
 	static unsigned long lastPrintSeconds = 0;
 	if (currentSeconds - lastPrintSeconds >= (unsigned long)configHandler.getConfigInterval("intervalPRINT"))
 	{
@@ -109,7 +109,6 @@ void setup()
 		Serial.println("Failed to mount LittleFS!");
 		return;
 	}
-	ConfigHandler &configHandler = ConfigHandler::getInstance();
 	configHandler.setSettingsOnFirstRun();
 
 	WiFiHandler::initWifi();
@@ -146,8 +145,6 @@ void loop()
 			last = currentSeconds;
 		}
 	}
-	ConfigHandler &configHandler = ConfigHandler::getInstance();
-
 	BME680Handler &bmehandler = BME680Handler::getInstance();
 	Bsec bme_data = bmehandler.getData();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -82,8 +82,10 @@ String localTime(const String &format)
 #ifdef DEBUG
 static void PrintRamUsage(unsigned long currentSeconds)
 {
-	if (currentSeconds % configHandler.getConfigInterval("intervalPRINT") == 0)
+	static unsigned long lastPrintSeconds = 0;
+	if (currentSeconds - lastPrintSeconds >= (unsigned long)configHandler.getConfigInterval("intervalPRINT"))
 	{
+		lastPrintSeconds = currentSeconds;
 		Serial.print("Memory Usage: ");
 		uint32_t freeHeap = ESP.getFreeHeap();
 		uint32_t maximumHeap = ESP.getHeapSize();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,7 +48,6 @@
 #include "LEDHandler.h"
 #include "MqttClientHandler.h"
 #include "ConfigHandler.h"
-ConfigHandler configHandler;
 #include <LittleFS.h>
 
 // --------------------------------------------------------------------------
@@ -82,6 +81,7 @@ String localTime(const String &format)
 #ifdef DEBUG
 static void PrintRamUsage(unsigned long currentSeconds)
 {
+	ConfigHandler &configHandler = ConfigHandler::getInstance();
 	static unsigned long lastPrintSeconds = 0;
 	if (currentSeconds - lastPrintSeconds >= (unsigned long)configHandler.getConfigInterval("intervalPRINT"))
 	{


### PR DESCRIPTION
**Features:**
add sensor settings on webpage (temperature offset, sea level pressure)
add module interval configuration on webpage
add LED brightness configuration on webpage
add module switch configuration on webpage (WiFi, EPD, LED, MQTT)
add user feedback after saving settings on webpage
add CO2 sensor automatic recovery mechanism
add mDNS hostname from device config
**Fixes:**
fix persistAllSettings() saving wrong map for intervals
fix persistAllSettings() missing LED, sensor and device values
fix brightness validation logic (inverted condition)
fix tempOffset stored as int instead of float (factor 10 scaling)
fix ESP.restart() called before HTTP response (xTaskCreate pattern)
fix MQTT publish condition inverted (connected == false → true)
fix MQTT server using hardcoded defines instead of config values
fix IAQ always returning 50 (bmeSensor.run() called too infrequently)
fix dead link /settings → /sensorsettings
fix style.css.gz not found error (replaced serveStatic with explicit routes)
fix plaintext WLAN password exposed in HTML source
fix configHandler multiple definition linker error (extern pattern)
fix SoftwareSerial replaced with HardwareSerial (Serial2) for MHZ19
fix modulo timing pattern replaced with lastRun pattern in all handlers
fix min attribute missing on interval inputs (prevent division by zero)
**Refactor:**
unify web interface structure (DOCTYPE, charset, nav/content/footer)
scope CSS selectors to prevent unintended style overrides
centralize configHandler as single global singleton reference
remove dead code (updateSensorDataInternal, unused String constants)
reduce duplicate fetch code with shared submitForm() helper function
remove saved credentials section from WLAN page
**Notes:**
C / C++
tested on Firebeetle V4 (used Flash 80.2%)
pin allocation in main.cpp
iaqAccuracy requires ~5 min to reach level 1 after first flash
LittleFS filesystem image must be uploaded separately after HTML changes