### PR TITLE
2609 fix mqtt

### DIFF
--- a/data/static/index.htm
+++ b/data/static/index.htm
@@ -14,8 +14,9 @@
             <div class="nav">
                 <a href="/status" class="button">Status</a>
                 <a href="/json" class="button">JSON</a>
-                <a href="/WLAN" class="button">WLAN Settings</a>
                 <a href="/sensorsettings" class="button">Sensor Settings</a>
+                <a href="/WLAN" class="button">WLAN Settings</a>
+                <a href="/mqtt" class="button">MQTT Settings</a>
             </div>
             <div class="content">
             </div>

--- a/data/static/mqtt.htm
+++ b/data/static/mqtt.htm
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>{{deviceName}} - MQTT Settings</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <link rel="stylesheet" href="/static/style.css">
+    </head>
+    <body>
+        <div class="container">
+            <div class="nav">
+                <a href="/index" class="button">Back to Index</a>
+            </div>
+            <div class="content">
+                <h1>MQTT Settings</h1>
+
+                <div id="mqttStatus">
+                    <h2>Connection Status</h2>
+                    <div class="status-item">
+                        <div class="title">Broker</div>
+                        <div class="data" id="statusHost">–</div>
+                        <div class="status-indicator" id="statusIndicator"></div>
+                        <div class="description" id="statusText">Loading...</div>
+                    </div>
+                </div>
+
+                <div id="mqttSwitch">
+                    <h2>Module Switch</h2>
+                    <form action="/submitMQTTconfig" method="POST" id="mqttSwitchForm">
+                        <div>
+                            <label for="switchMQTT">Enable MQTT
+                                <input type="checkbox" id="switchMQTT" name="switchMQTT" {{switchMQTT_checked}} title="Send sensor data via MQTT">
+                            </label>
+                        </div>
+                        <button type="submit" class="btn">Save</button>
+                        <div class="form-feedback" id="feedbackSwitch"></div>
+                    </form>
+                </div>
+
+                <div id="mqttCredentials">
+                    <h2>Broker Configuration</h2>
+                    <form action="/submitMQTTconfig" method="POST" id="mqttConfigForm">
+                        <div>
+                            <label for="mqttHOST">Host / IP
+                                <input type="text" id="mqttHOST" name="mqttHOST" value="{{mqttHOST}}" placeholder="192.168.1.100">
+                            </label>
+                        </div>
+                        <div>
+                            <label for="mqttPORT">Port
+                                <input type="number" id="mqttPORT" name="mqttPORT" value="{{mqttPORT}}" min="1" max="65535">
+                            </label>
+                        </div>
+                        <div>
+                            <label for="mqttUSERen">Use Credentials
+                                <input type="checkbox" id="mqttUSERen" name="mqttUSERen" {{mqttUSERen_checked}}>
+                            </label>
+                        </div>
+                        <div id="credentialsFields">
+                            <div>
+                                <label for="mqttUSER">Username
+                                    <input type="text" id="mqttUSER" name="mqttUSER" value="{{mqttUSER}}">
+                                </label>
+                            </div>
+                            <div>
+                                <label for="mqttPASSWORD">Password
+                                    <input type="password" id="mqttPASSWORD" name="mqttPASSWORD" placeholder="leave empty to keep current">
+                                </label>
+                            </div>
+                        </div>
+                        <button type="submit" class="btn">Save Configuration</button>
+                        <div class="form-feedback" id="feedbackConfig"></div>
+                    </form>
+                </div>
+            </div>
+        </div>
+        <div class="footer">&copy; 2025 SensorTurtle</div>
+
+        <script>
+            document.addEventListener("DOMContentLoaded", function () {
+
+                function showFeedback(elementId, success) {
+                    const el = document.getElementById(elementId);
+                    el.textContent = success ? "Saved successfully!" : "Error saving settings.";
+                    el.className = "form-feedback " + (success ? "success" : "error");
+                    setTimeout(() => {
+                        el.textContent = "";
+                        el.className = "form-feedback";
+                    }, 3000);
+                }
+
+                function submitForm(url, params, feedbackId) {
+                    fetch(url, {
+                        method: "POST",
+                        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+                        body: params
+                    })
+                    .then(response => showFeedback(feedbackId, response.ok))
+                    .catch(() => showFeedback(feedbackId, false));
+                }
+
+                // Verbindungsstatus laden
+                fetch("/api/mqtt/status")
+                    .then(response => response.json())
+                    .then(data => {
+                        const indicator = document.getElementById("statusIndicator");
+                        const statusText = document.getElementById("statusText");
+                        const statusHost = document.getElementById("statusHost");
+
+                        statusHost.textContent = document.getElementById("mqttHOST").value || "–";
+
+                        if (data.connected) {
+                            indicator.style.backgroundColor = "#28a745";
+                            statusText.textContent = "Connected";
+                        } else if (data.hasCredentials) {
+                            indicator.style.backgroundColor = "#ffc107";
+                            statusText.textContent = "Not connected – broker configured but unreachable";
+                        } else {
+                            indicator.style.backgroundColor = "#dc3545";
+                            statusText.textContent = "Not connected – no broker configured";
+                        }
+                    })
+                    .catch(() => {
+                        document.getElementById("statusText").textContent = "Status unavailable";
+                    });
+
+                // Credentials Felder ein-/ausblenden
+                const mqttUSERen = document.getElementById("mqttUSERen");
+                const credentialsFields = document.getElementById("credentialsFields");
+
+                function toggleCredentials() {
+                    credentialsFields.style.display = mqttUSERen.checked ? "block" : "none";
+                }
+                mqttUSERen.addEventListener("change", toggleCredentials);
+                toggleCredentials();
+
+                // Switch Form
+                const switchForm = document.getElementById("mqttSwitchForm");
+                switchForm.addEventListener("submit", function (event) {
+                    event.preventDefault();
+                    const checked = document.getElementById("switchMQTT").checked;
+                    submitForm("/submitMQTTconfig", `switchMQTT=${checked ? 1 : 0}`, "feedbackSwitch");
+                });
+
+                // Config Form
+                const configForm = document.getElementById("mqttConfigForm");
+                configForm.addEventListener("submit", function (event) {
+                    event.preventDefault();
+                    const inputs = configForm.querySelectorAll("input");
+                    const params = Array.from(inputs).map(input => {
+                        if (input.type === "checkbox") {
+                            return `${encodeURIComponent(input.name)}=${input.checked ? 1 : 0}`;
+                        }
+                        return `${encodeURIComponent(input.name)}=${encodeURIComponent(input.value)}`;
+                    }).join("&");
+                    submitForm("/submitMQTTconfig", params, "feedbackConfig");
+                });
+            });
+        </script>
+    </body>
+</html>

--- a/data/static/settings.htm
+++ b/data/static/settings.htm
@@ -30,11 +30,6 @@
                                 <input type="checkbox" id="switchLED" name="switchLED" {{switchLED_checked}} title="Display sensor data on LED strips">
                             </label>
                         </div>
-                        <div>
-                            <label for="switchMQTT">MQTT
-                                <input type="checkbox" id="switchMQTT" name="switchMQTT" {{switchMQTT_checked}} title="Send sensor data via MQTT">
-                            </label>
-                        </div>
                         <button type="submit" class="btn" id="saveModulBtn">Save Settings</button>
                         <div class="form-feedback" id="feedbackSwitch"></div>
                     </form>

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -38,10 +38,10 @@
 #define LED_TYPE WS2812B
 #define COLOR_ORDER GRB
 
-#define MQTT_HOST "192.168.178.38"
 //#define MQTT_HOST "example.com"
+#define MQTT_HOST ""
 #define MQTT_PORT 1883
-#define MQTT_USER_ENABLED 1
+#define MQTT_USER_ENABLED 0
 
 
 extern const char* DeviceNameConf;

--- a/src/Credentials_example.h
+++ b/src/Credentials_example.h
@@ -7,4 +7,7 @@
 #define WIFI_SSID "";
 #define WIFI_PW "";
 
+#define MQTT_USER "";
+#define MQTT_PASS "";
+
 #endif

--- a/src/MqttClientHandler.cpp
+++ b/src/MqttClientHandler.cpp
@@ -108,6 +108,5 @@ void MqttClientHandler::publishData(const DataCO2 data_co2, const Bsec data_bme,
 			Serial.println("[MQTT] No data send");
 #endif
 		}
-		disconnectfromMqtt();
 	}
 }

--- a/src/MqttClientHandler.cpp
+++ b/src/MqttClientHandler.cpp
@@ -22,14 +22,6 @@ void MqttClientHandler::connectToMqtt()
 	}
 }
 
-void MqttClientHandler::disconnectfromMqtt()
-{
-	if (mqttClient.connected() == true)
-	{
-		mqttClient.disconnect();
-	}
-}
-
 void MqttClientHandler::WiFiEvent(WiFiEvent_t event)
 {
 	Serial.printf("[MQTT] event: %d\n", event);

--- a/src/MqttClientHandler.cpp
+++ b/src/MqttClientHandler.cpp
@@ -82,13 +82,13 @@ void MqttClientHandler::publishData(const DataCO2 data_co2, const Bsec data_bme,
 			mqttClient.publish("sensor/bme680/iaqAccuracy", 1, true, String(data_bme.iaqAccuracy).c_str());
 			mqttClient.publish("sensor/bme680/staticIaqAccuracy", 1, true, String(data_bme.staticIaqAccuracy).c_str());
 
-			mqttClient.publish("sensor/mhz19/Accuracy", 1, true, String(data_co2.getAccuracy()).c_str());
-			mqttClient.publish("sensor/mhz19/Background", 1, true, String(data_co2.getBackground()).c_str());
-			mqttClient.publish("sensor/mhz19/Limited", 1, true, String(data_co2.getLimited()).c_str());
-			mqttClient.publish("sensor/mhz19/Raw", 1, true, String(data_co2.getRaw()).c_str());
-			mqttClient.publish("sensor/mhz19/Regular", 1, true, String(data_co2.getRegular()).c_str());
-			mqttClient.publish("sensor/mhz19/TempAdjustment", 1, true, String(data_co2.getTempAdjustment()).c_str());
-			mqttClient.publish("sensor/mhz19/Temperature", 1, true, String(data_co2.getTemperature()).c_str());
+			mqttClient.publish("sensor/mhz19/accuracy", 1, true, String(data_co2.getAccuracy()).c_str());
+			mqttClient.publish("sensor/mhz19/background", 1, true, String(data_co2.getBackground()).c_str());
+			mqttClient.publish("sensor/mhz19/limited", 1, true, String(data_co2.getLimited()).c_str());
+			mqttClient.publish("sensor/mhz19/raw", 1, true, String(data_co2.getRaw()).c_str());
+			mqttClient.publish("sensor/mhz19/regular", 1, true, String(data_co2.getRegular()).c_str());
+			mqttClient.publish("sensor/mhz19/tempAdjustment", 1, true, String(data_co2.getTempAdjustment()).c_str());
+			mqttClient.publish("sensor/mhz19/temperature", 1, true, String(data_co2.getTemperature()).c_str());
 
 #ifdef DEBUG
 			Serial.println("[MQTT] Send data");

--- a/src/MqttClientHandler.cpp
+++ b/src/MqttClientHandler.cpp
@@ -22,6 +22,11 @@ void MqttClientHandler::connectToMqtt()
 	}
 }
 
+bool MqttClientHandler::isConnected()
+{
+    return mqttClient.connected();
+}
+
 void MqttClientHandler::WiFiEvent(WiFiEvent_t event)
 {
 	Serial.printf("[MQTT] event: %d\n", event);
@@ -48,9 +53,18 @@ void MqttClientHandler::setup_Mqtt()
 
 	mqttClient.onDisconnect(onMqttDisconnect);
 
-	mqttClient.setServer(MQTT_HOST, MQTT_PORT);
-	mqttClient.setCredentials(MQTT_USER, MQTT_PASS);
-	Serial.println("[MQTT] connected");
+	String host = configHandler.getConfigDevice("mqttHOST");
+	int port = configHandler.getConfigDevice("mqttPORT").toInt();
+	mqttClient.setServer(host.c_str(), port);
+
+	if (configHandler.getConfigDevice("mqttUSERen") == "1")
+	{
+		mqttClient.setCredentials(
+			configHandler.getConfigDevice("mqttUSER").c_str(),
+			configHandler.getConfigDevice("mqttPASSWORD").c_str()
+		);
+	}
+	Serial.println("[MQTT] setup done, server: " + host + ":" + String(port));
 }
 
 void MqttClientHandler::publishData(const DataCO2 data_co2, const Bsec data_bme, const unsigned long currentSeconds)

--- a/src/MqttClientHandler.cpp
+++ b/src/MqttClientHandler.cpp
@@ -67,7 +67,7 @@ void MqttClientHandler::publishData(const DataCO2 data_co2, const Bsec data_bme,
 	{
 		_lastRunSeconds = currentSeconds;
 		connectToMqtt();
-		if (mqttClient.connected() == false)
+		if (mqttClient.connected() == true)
 		{
 			mqttClient.publish("sensor/bme680/temperature", 1, true, String(data_bme.temperature).c_str());
 			mqttClient.publish("sensor/bme680/temperature_offset", 1, true, String(data_bme.temperature + configHandler.getConfigSensor("tempOffset") / 10.0f).c_str());

--- a/src/MqttClientHandler.h
+++ b/src/MqttClientHandler.h
@@ -22,7 +22,6 @@ public:
 private:
 	static void WiFiEvent(WiFiEvent_t event);
 	static void connectToMqtt();
-	static void disconnectfromMqtt();
 	static void onMqttDisconnect(AsyncMqttClientDisconnectReason reason);
 	static unsigned long _lastRunSeconds;
 };

--- a/src/MqttClientHandler.h
+++ b/src/MqttClientHandler.h
@@ -18,6 +18,7 @@ public:
 	}
 	static void publishData(const DataCO2 co2, const Bsec bme_data, unsigned long currentSeconds);
 	void setup_Mqtt();
+	static bool isConnected();
 
 private:
 	static void WiFiEvent(WiFiEvent_t event);

--- a/src/WebServerHandler.cpp
+++ b/src/WebServerHandler.cpp
@@ -4,6 +4,7 @@
 #include <LittleFS.h>
 #include "MHZ19Handler.h"
 #include "ConfigHandler.h"
+#include "MqttClientHandler.h"
 #include "LEDHandler.h"
 extern ConfigHandler &configHandler;
 
@@ -35,6 +36,12 @@ void WebServerHandler::start()
 	server.on("/restoredefaultconfiguration", HTTP_POST, [this](AsyncWebServerRequest *request) {handle_option_restoreDefaultConfiguration(request); });
 	server.on("/restart", HTTP_POST, [this](AsyncWebServerRequest *request) {handle_option_restart(request); });
 	server.on("/calibrateMHZ19", HTTP_POST, [this](AsyncWebServerRequest *request) { handle_option_calibrate_mhz19(request); });
+
+	//mqtt
+	server.on("/mqtt", HTTP_GET, [this](AsyncWebServerRequest *request) {handle_page_mqtt(request); });
+	server.on("/submitMQTTconfig", HTTP_POST, [this](AsyncWebServerRequest *request) {handle_submit_mqttconfig(request); });
+	server.on("/api/mqtt/status", HTTP_GET, [this](AsyncWebServerRequest *request) {handle_api_mqtt_status(request); });
+	
 	server.onNotFound(handle_page_NotFound);
 	server.begin();
 }
@@ -447,6 +454,77 @@ void WebServerHandler::handle_option_calibrate_mhz19(AsyncWebServerRequest *requ
 	delay(1000);
 	request->redirect("/sensorsettings");
 }
+
+
+// --------------------
+// MQTT Handlers
+// --------------------
+void WebServerHandler::handle_page_mqtt(AsyncWebServerRequest *request)
+{
+    File file = LittleFS.open("/static/mqtt.htm", "r");
+    if (!file)
+    {
+        request->send(500, "text/plain", "Internal Server Error: Cannot open mqtt.htm");
+        return;
+    }
+    String content = file.readString();
+    file.close();
+
+    content.replace("{{deviceName}}", DeviceName);
+    content.replace("{{mqttHOST}}", configHandler.getConfigDevice("mqttHOST"));
+    content.replace("{{mqttPORT}}", configHandler.getConfigDevice("mqttPORT"));
+    content.replace("{{mqttUSERen_checked}}", configHandler.getConfigDevice("mqttUSERen") == "1" ? "checked" : "");
+    content.replace("{{mqttUSER}}", configHandler.getConfigDevice("mqttUSER"));
+    content.replace("{{switchMQTT_checked}}", configHandler.getConfigSwitch("switchMQTT") ? "checked" : "");
+
+    request->send(200, "text/html", content);
+}
+
+void WebServerHandler::handle_submit_mqttconfig(AsyncWebServerRequest *request)
+{
+    bool updated = false;
+
+    if (request->hasParam("mqttHOST", true)) {
+        configHandler.setConfigDevice("mqttHOST", request->getParam("mqttHOST", true)->value());
+        updated = true;
+    }
+    if (request->hasParam("mqttPORT", true)) {
+        configHandler.setConfigDevice("mqttPORT", request->getParam("mqttPORT", true)->value());
+        updated = true;
+    }
+    if (request->hasParam("mqttUSER", true)) {
+        configHandler.setConfigDevice("mqttUSER", request->getParam("mqttUSER", true)->value());
+        updated = true;
+    }
+    if (request->hasParam("mqttPASSWORD", true)) {
+        configHandler.setConfigDevice("mqttPASSWORD", request->getParam("mqttPASSWORD", true)->value());
+        updated = true;
+    }
+    configHandler.setConfigDevice("mqttUSERen",
+        request->hasParam("mqttUSERen", true) ? "1" : "0");
+
+    if (request->hasParam("switchMQTT", true)) {
+        configHandler.setConfigSwitch("switchMQTT",
+            atoi(request->getParam("switchMQTT", true)->value().c_str()));
+    }
+
+    if (updated) {
+        configHandler.persistAllSettings();
+        request->send(200, "text/plain", "MQTT configuration saved!");
+    } else {
+        request->send(400, "text/plain", "Bad Request: Missing parameters");
+    }
+}
+
+void WebServerHandler::handle_api_mqtt_status(AsyncWebServerRequest *request)
+{
+    bool connected = MqttClientHandler::isConnected();
+    bool hasHost = configHandler.getConfigDevice("mqttHOST") != "";
+    String json = "{\"connected\":" + String(connected ? "true" : "false") +
+                  ",\"hasCredentials\":" + String(hasHost ? "true" : "false") + "}";
+    request->send(200, "application/json", json);
+}
+
 
 // --------------------
 // Helpers

--- a/src/WebServerHandler.cpp
+++ b/src/WebServerHandler.cpp
@@ -228,7 +228,6 @@ void WebServerHandler::handle_page_settings(AsyncWebServerRequest *request)
 	content.replace("{{switchWIFI_checked}}", configHandler.getConfigSwitch("switchWIFI") ? "checked" : "");
 	content.replace("{{switchEPD_checked}}", configHandler.getConfigSwitch("switchEPD") ? "checked" : "");
 	content.replace("{{switchLED_checked}}", configHandler.getConfigSwitch("switchLED") ? "checked" : "");
-	content.replace("{{switchMQTT_checked}}", configHandler.getConfigSwitch("switchMQTT") ? "checked" : "");
 
 	content.replace("{{LEDbrightness}}", String(configHandler.getConfigLED("LEDbrightness")));
 	content.replace("{{SEALEVELPRESSURE_HPA}}", String(configHandler.getConfigSensor("pressure")));
@@ -361,10 +360,6 @@ void WebServerHandler::handle_submit_modulswitch(AsyncWebServerRequest *request)
 	{
 		configHandler.setConfigSwitch("switchLED", atoi(request->getParam("switchLED")->value().c_str()));
 	}
-	if (request->hasParam("switchMQTT"))
-	{
-		configHandler.setConfigSwitch("switchMQTT", atoi(request->getParam("switchMQTT")->value().c_str()));
-	} 
 	configHandler.persistAllSettings();
 	request->send(200, "text/plain", "Modul Settings Saved!");
 	request->redirect("/sensorsettings");

--- a/src/WebServerHandler.cpp
+++ b/src/WebServerHandler.cpp
@@ -41,7 +41,7 @@ void WebServerHandler::start()
 	server.on("/mqtt", HTTP_GET, [this](AsyncWebServerRequest *request) {handle_page_mqtt(request); });
 	server.on("/submitMQTTconfig", HTTP_POST, [this](AsyncWebServerRequest *request) {handle_submit_mqttconfig(request); });
 	server.on("/api/mqtt/status", HTTP_GET, [this](AsyncWebServerRequest *request) {handle_api_mqtt_status(request); });
-	
+
 	server.onNotFound(handle_page_NotFound);
 	server.begin();
 }
@@ -475,7 +475,6 @@ void WebServerHandler::handle_page_mqtt(AsyncWebServerRequest *request)
     content.replace("{{mqttPORT}}", configHandler.getConfigDevice("mqttPORT"));
     content.replace("{{mqttUSERen_checked}}", configHandler.getConfigDevice("mqttUSERen") == "1" ? "checked" : "");
     content.replace("{{mqttUSER}}", configHandler.getConfigDevice("mqttUSER"));
-    content.replace("{{switchMQTT_checked}}", configHandler.getConfigSwitch("switchMQTT") ? "checked" : "");
 
     request->send(200, "text/html", content);
 }

--- a/src/WebServerHandler.h
+++ b/src/WebServerHandler.h
@@ -46,6 +46,11 @@ private:
 	void handle_option_calibrate_mhz19(AsyncWebServerRequest *request);
 
 
+	void handle_page_mqtt(AsyncWebServerRequest *request);
+	void handle_submit_mqttconfig(AsyncWebServerRequest *request);
+	void handle_api_mqtt_status(AsyncWebServerRequest *request);
+
+
 	// helper function
 	void replaceColorDescr(String &str, const String &key, const String &color, const String &descr);
 	void replaceIaqAccuracy(String &str, int iaqAccuracy);


### PR DESCRIPTION
**Summary**
Fixes the MQTT implementation and adds a dedicated MQTT settings page with broker configuration, credentials management and live connection status.
**Bug Fixes**
fix: MQTT publish condition was inverted (connected == false → true)
fix: MQTT setup used hardcoded defines instead of config values
fix: duplicate switchMQTT handling in settings handler removed
**Features**
feat: add dedicated MQTT settings page (/mqtt)
feat: add broker configuration (host, port) via web interface
feat: add MQTT credentials management (user, password) via web interface
feat: add MQTT connection status indicator (connected / unreachable / not configured)
feat: add mqttUSERen toggle to show/hide credentials fields
feat: add /api/mqtt/status endpoint returning JSON connection state
feat: add isConnected() method to MqttClientHandler
**Refactor**
refactor: MQTT setup reads host, port and credentials from ConfigHandler
refactor: remove switchMQTT from sensor settings page (moved to MQTT page)
refactor: remove disconnectfromMqtt() – connection stays open persistently
refactor: unify MQTT topic naming to lowercase
refactor: MQTT credentials moved from hardcoded defines to Credentials_example.h
refactor: MQTT_HOST default set to empty string, MQTT_USER_ENABLED default set to 0
**Notes**
LittleFS filesystem image must be re-uploaded after this PR
MQTT switch is now exclusively managed on the /mqtt page
ESP32 restart required after changing broker host or port