### PR TITLE
2609 mqtt discovery

### DIFF
--- a/src/MqttClientHandler.cpp
+++ b/src/MqttClientHandler.cpp
@@ -71,8 +71,8 @@ void MqttClientHandler::publishDiscovery()
 {
     if (!mqttClient.connected()) return;
 
-    // Device JSON – wird in jeder Config-Nachricht wiederverwendet
-    String device = "\"device\":{\"identifiers\":[\"sensorturtle\"],\"name\":\"SensorTurtle\",\"model\":\"Firebeetle ESP32\",\"manufacturer\":\"SensorTurtle\"}";
+    String deviceBME = "\"device\":{\"identifiers\":[\"sensorturtle_bme680\"],\"name\":\"SensorTurtle BME680\",\"model\":\"BME680\",\"manufacturer\":\"Bosch\",\"via_device\":\"sensorturtle\"}";
+    String deviceMHZ = "\"device\":{\"identifiers\":[\"sensorturtle_mhz19\"],\"name\":\"SensorTurtle MHZ19\",\"model\":\"MH-Z19B\",\"manufacturer\":\"Winsen\",\"via_device\":\"sensorturtle\"}";
 
     struct SensorConfig {
         const char* uniqueId;
@@ -81,30 +81,31 @@ void MqttClientHandler::publishDiscovery()
         const char* unit;
         const char* deviceClass;
         const char* stateClass;
+        bool isBME;
     };
 
     SensorConfig sensors[] = {
         // BME680
-        {"temperature",         "Temperature",          "homeassistant/sensor/sensorturtle/temperature/state",          "°C",    "temperature",    "measurement"},
-        {"temperature_offset",  "Temperature (Offset)", "homeassistant/sensor/sensorturtle/temperature_offset/state",   "°C",    "temperature",    "measurement"},
-        {"humidity",            "Humidity",             "homeassistant/sensor/sensorturtle/humidity/state",             "%",     "humidity",       "measurement"},
-        {"pressure",            "Air Pressure",         "homeassistant/sensor/sensorturtle/pressure/state",             "hPa",   "pressure",       "measurement"},
-        {"gas",                 "Gas Resistance",       "homeassistant/sensor/sensorturtle/gas/state",                  "Ω",     "",               "measurement"},
-        {"iaq",                 "IAQ",                  "homeassistant/sensor/sensorturtle/iaq/state",                  "",      "",               "measurement"},
-        {"iaq_accuracy",        "IAQ Accuracy",         "homeassistant/sensor/sensorturtle/iaq_accuracy/state",         "",      "",               "measurement"},
-        {"breath_voc",          "Breath VOC",           "homeassistant/sensor/sensorturtle/breath_voc/state",           "ppm",   "",               "measurement"},
-        {"co2_equivalent",      "CO2 Equivalent",       "homeassistant/sensor/sensorturtle/co2_equivalent/state",       "ppm",   "carbon_dioxide", "measurement"},
-        {"static_iaq_accuracy", "Static IAQ Accuracy",  "homeassistant/sensor/sensorturtle/static_iaq_accuracy/state",  "",      "",               "measurement"},
-        {"comp_gas_value",      "Comp Gas Value",       "homeassistant/sensor/sensorturtle/comp_gas_value/state",       "",      "",               "measurement"},
-        {"gas_percentage",      "Gas Percentage",       "homeassistant/sensor/sensorturtle/gas_percentage/state",       "%",     "",               "measurement"},
+        {"temperature",         "Temperature",          "homeassistant/sensor/sensorturtle/temperature/state",          "°C",  "temperature",    "measurement", true},
+        {"temperature_offset",  "Temperature (Offset)", "homeassistant/sensor/sensorturtle/temperature_offset/state",   "°C",  "temperature",    "measurement", true},
+        {"humidity",            "Humidity",             "homeassistant/sensor/sensorturtle/humidity/state",             "%",   "humidity",       "measurement", true},
+        {"pressure",            "Air Pressure",         "homeassistant/sensor/sensorturtle/pressure/state",             "hPa", "pressure",       "measurement", true},
+        {"gas",                 "Gas Resistance",       "homeassistant/sensor/sensorturtle/gas/state",                  "Ω",   "",               "measurement", true},
+        {"iaq",                 "IAQ",                  "homeassistant/sensor/sensorturtle/iaq/state",                  "",    "",               "measurement", true},
+        {"iaq_accuracy",        "IAQ Accuracy",         "homeassistant/sensor/sensorturtle/iaq_accuracy/state",         "",    "",               "measurement", true},
+        {"breath_voc",          "Breath VOC",           "homeassistant/sensor/sensorturtle/breath_voc/state",           "ppm", "",               "measurement", true},
+        {"co2_equivalent",      "CO2 Equivalent",       "homeassistant/sensor/sensorturtle/co2_equivalent/state",       "ppm", "carbon_dioxide", "measurement", true},
+        {"static_iaq_accuracy", "Static IAQ Accuracy",  "homeassistant/sensor/sensorturtle/static_iaq_accuracy/state",  "",    "",               "measurement", true},
+        {"comp_gas_value",      "Comp Gas Value",       "homeassistant/sensor/sensorturtle/comp_gas_value/state",       "",    "",               "measurement", true},
+        {"gas_percentage",      "Gas Percentage",       "homeassistant/sensor/sensorturtle/gas_percentage/state",       "%",   "",               "measurement", true},
         // MHZ19
-        {"co2",                 "CO2",                  "homeassistant/sensor/sensorturtle/co2/state",                  "ppm",   "carbon_dioxide", "measurement"},
-        {"co2_raw",             "CO2 Raw",              "homeassistant/sensor/sensorturtle/co2_raw/state",              "ppm",   "carbon_dioxide", "measurement"},
-        {"co2_accuracy",        "CO2 Accuracy",         "homeassistant/sensor/sensorturtle/co2_accuracy/state",         "",      "",               "measurement"},
-        {"co2_limited",         "CO2 Limited",          "homeassistant/sensor/sensorturtle/co2_limited/state",          "ppm",   "carbon_dioxide", "measurement"},
-        {"co2_background",      "CO2 Background",       "homeassistant/sensor/sensorturtle/co2_background/state",       "ppm",   "carbon_dioxide", "measurement"},
-        {"co2_temp_adjustment", "CO2 Temp Adjustment",  "homeassistant/sensor/sensorturtle/co2_temp_adjustment/state",  "",      "",               "measurement"},
-        {"co2_temperature",     "CO2 Temperature",      "homeassistant/sensor/sensorturtle/co2_temperature/state",      "°C",    "temperature",    "measurement"},
+        {"co2",                 "CO2",                  "homeassistant/sensor/sensorturtle/co2/state",                  "ppm", "carbon_dioxide", "measurement", false},
+        {"co2_raw",             "CO2 Raw",              "homeassistant/sensor/sensorturtle/co2_raw/state",              "ppm", "carbon_dioxide", "measurement", false},
+        {"co2_accuracy",        "CO2 Accuracy",         "homeassistant/sensor/sensorturtle/co2_accuracy/state",         "",    "",               "measurement", false},
+        {"co2_limited",         "CO2 Limited",          "homeassistant/sensor/sensorturtle/co2_limited/state",          "ppm", "carbon_dioxide", "measurement", false},
+        {"co2_background",      "CO2 Background",       "homeassistant/sensor/sensorturtle/co2_background/state",       "ppm", "carbon_dioxide", "measurement", false},
+        {"co2_temp_adjustment", "CO2 Temp Adjustment",  "homeassistant/sensor/sensorturtle/co2_temp_adjustment/state",  "",    "",               "measurement", false},
+        {"co2_temperature",     "CO2 Temperature",      "homeassistant/sensor/sensorturtle/co2_temperature/state",      "°C",  "temperature",    "measurement", false},
     };
 
     for (auto& s : sensors)
@@ -122,7 +123,7 @@ void MqttClientHandler::publishDiscovery()
         if (strlen(s.deviceClass) > 0)
             payload += "\"device_class\":\"" + String(s.deviceClass) + "\",";
         payload += "\"state_class\":\"" + String(s.stateClass) + "\",";
-        payload += device;
+        payload += (s.isBME ? deviceBME : deviceMHZ);
         payload += "}";
 
         mqttClient.publish(configTopic.c_str(), 1, true, payload.c_str());

--- a/src/MqttClientHandler.cpp
+++ b/src/MqttClientHandler.cpp
@@ -67,6 +67,70 @@ void MqttClientHandler::setup_Mqtt()
 	Serial.println("[MQTT] setup done, server: " + host + ":" + String(port));
 }
 
+void MqttClientHandler::publishDiscovery()
+{
+    if (!mqttClient.connected()) return;
+
+    // Device JSON – wird in jeder Config-Nachricht wiederverwendet
+    String device = "\"device\":{\"identifiers\":[\"sensorturtle\"],\"name\":\"SensorTurtle\",\"model\":\"Firebeetle ESP32\",\"manufacturer\":\"SensorTurtle\"}";
+
+    struct SensorConfig {
+        const char* uniqueId;
+        const char* name;
+        const char* stateTopic;
+        const char* unit;
+        const char* deviceClass;
+        const char* stateClass;
+    };
+
+    SensorConfig sensors[] = {
+        // BME680
+        {"temperature",         "Temperature",          "homeassistant/sensor/sensorturtle/temperature/state",          "°C",    "temperature",    "measurement"},
+        {"temperature_offset",  "Temperature (Offset)", "homeassistant/sensor/sensorturtle/temperature_offset/state",   "°C",    "temperature",    "measurement"},
+        {"humidity",            "Humidity",             "homeassistant/sensor/sensorturtle/humidity/state",             "%",     "humidity",       "measurement"},
+        {"pressure",            "Air Pressure",         "homeassistant/sensor/sensorturtle/pressure/state",             "hPa",   "pressure",       "measurement"},
+        {"gas",                 "Gas Resistance",       "homeassistant/sensor/sensorturtle/gas/state",                  "Ω",     "",               "measurement"},
+        {"iaq",                 "IAQ",                  "homeassistant/sensor/sensorturtle/iaq/state",                  "",      "",               "measurement"},
+        {"iaq_accuracy",        "IAQ Accuracy",         "homeassistant/sensor/sensorturtle/iaq_accuracy/state",         "",      "",               "measurement"},
+        {"breath_voc",          "Breath VOC",           "homeassistant/sensor/sensorturtle/breath_voc/state",           "ppm",   "",               "measurement"},
+        {"co2_equivalent",      "CO2 Equivalent",       "homeassistant/sensor/sensorturtle/co2_equivalent/state",       "ppm",   "carbon_dioxide", "measurement"},
+        {"static_iaq_accuracy", "Static IAQ Accuracy",  "homeassistant/sensor/sensorturtle/static_iaq_accuracy/state",  "",      "",               "measurement"},
+        {"comp_gas_value",      "Comp Gas Value",       "homeassistant/sensor/sensorturtle/comp_gas_value/state",       "",      "",               "measurement"},
+        {"gas_percentage",      "Gas Percentage",       "homeassistant/sensor/sensorturtle/gas_percentage/state",       "%",     "",               "measurement"},
+        // MHZ19
+        {"co2",                 "CO2",                  "homeassistant/sensor/sensorturtle/co2/state",                  "ppm",   "carbon_dioxide", "measurement"},
+        {"co2_raw",             "CO2 Raw",              "homeassistant/sensor/sensorturtle/co2_raw/state",              "ppm",   "carbon_dioxide", "measurement"},
+        {"co2_accuracy",        "CO2 Accuracy",         "homeassistant/sensor/sensorturtle/co2_accuracy/state",         "",      "",               "measurement"},
+        {"co2_limited",         "CO2 Limited",          "homeassistant/sensor/sensorturtle/co2_limited/state",          "ppm",   "carbon_dioxide", "measurement"},
+        {"co2_background",      "CO2 Background",       "homeassistant/sensor/sensorturtle/co2_background/state",       "ppm",   "carbon_dioxide", "measurement"},
+        {"co2_temp_adjustment", "CO2 Temp Adjustment",  "homeassistant/sensor/sensorturtle/co2_temp_adjustment/state",  "",      "",               "measurement"},
+        {"co2_temperature",     "CO2 Temperature",      "homeassistant/sensor/sensorturtle/co2_temperature/state",      "°C",    "temperature",    "measurement"},
+    };
+
+    for (auto& s : sensors)
+    {
+        String configTopic = "homeassistant/sensor/sensorturtle/";
+        configTopic += s.uniqueId;
+        configTopic += "/config";
+
+        String payload = "{";
+        payload += "\"unique_id\":\"sensorturtle_" + String(s.uniqueId) + "\",";
+        payload += "\"name\":\"" + String(s.name) + "\",";
+        payload += "\"state_topic\":\"" + String(s.stateTopic) + "\",";
+        if (strlen(s.unit) > 0)
+            payload += "\"unit_of_measurement\":\"" + String(s.unit) + "\",";
+        if (strlen(s.deviceClass) > 0)
+            payload += "\"device_class\":\"" + String(s.deviceClass) + "\",";
+        payload += "\"state_class\":\"" + String(s.stateClass) + "\",";
+        payload += device;
+        payload += "}";
+
+        mqttClient.publish(configTopic.c_str(), 1, true, payload.c_str());
+    }
+
+    Serial.println("[MQTT] Discovery published");
+}
+
 void MqttClientHandler::publishData(const DataCO2 data_co2, const Bsec data_bme, const unsigned long currentSeconds)
 {
 	if (currentSeconds - _lastRunSeconds >= (unsigned long)configHandler.getConfigInterval("intervalMQTT"))

--- a/src/MqttClientHandler.cpp
+++ b/src/MqttClientHandler.cpp
@@ -139,34 +139,28 @@ void MqttClientHandler::publishData(const DataCO2 data_co2, const Bsec data_bme,
 		connectToMqtt();
 		if (mqttClient.connected() == true)
 		{
-			mqttClient.publish("sensor/bme680/temperature", 1, true, String(data_bme.temperature).c_str());
-			mqttClient.publish("sensor/bme680/temperature_offset", 1, true, String(data_bme.temperature + configHandler.getConfigSensor("tempOffset") / 10.0f).c_str());
-			mqttClient.publish("sensor/bme680/temperature_raw", 1, true, String(data_bme.rawTemperature).c_str());
-			mqttClient.publish("sensor/bme680/humidity", 1, true, String(data_bme.humidity).c_str());
-			mqttClient.publish("sensor/bme680/humidity_raw", 1, true, String(data_bme.rawHumidity).c_str());
-			mqttClient.publish("sensor/bme680/pressure", 1, true, String(data_bme.pressure).c_str());
-			mqttClient.publish("sensor/bme680/gas", 1, true, String(data_bme.gasResistance).c_str());
-			mqttClient.publish("sensor/bme680/bme68xStatus", 1, true, String(data_bme.bme68xStatus).c_str());
-			mqttClient.publish("sensor/bme680/breathVocAccuracy", 1, true, String(data_bme.breathVocAccuracy).c_str());
-			mqttClient.publish("sensor/bme680/breathVocEquivalent", 1, true, String(data_bme.breathVocEquivalent).c_str());
-			mqttClient.publish("sensor/bme680/bsecStatus", 1, true, String(data_bme.bsecStatus).c_str());
-			mqttClient.publish("sensor/bme680/co2Accuracy", 1, true, String(data_bme.co2Accuracy).c_str());
-			mqttClient.publish("sensor/bme680/co2Equivalent", 1, true, String(data_bme.co2Equivalent).c_str());
-			mqttClient.publish("sensor/bme680/compGasAccuracy", 1, true, String(data_bme.compGasAccuracy).c_str());
-			mqttClient.publish("sensor/bme680/compGasValue", 1, true, String(data_bme.compGasValue).c_str());
-			mqttClient.publish("sensor/bme680/gasPercentage", 1, true, String(data_bme.gasPercentage).c_str());
-			mqttClient.publish("sensor/bme680/gasPercentageAccuracy", 1, true, String(data_bme.gasPercentageAccuracy).c_str());
-			mqttClient.publish("sensor/bme680/iaq", 1, true, String(data_bme.iaq).c_str());
-			mqttClient.publish("sensor/bme680/iaqAccuracy", 1, true, String(data_bme.iaqAccuracy).c_str());
-			mqttClient.publish("sensor/bme680/staticIaqAccuracy", 1, true, String(data_bme.staticIaqAccuracy).c_str());
+			// BME680
+			mqttClient.publish("homeassistant/sensor/sensorturtle/temperature/state",         1, true, String(data_bme.temperature).c_str());
+			mqttClient.publish("homeassistant/sensor/sensorturtle/temperature_offset/state",  1, true, String(data_bme.temperature + configHandler.getConfigSensor("tempOffset") / 10.0f).c_str());
+			mqttClient.publish("homeassistant/sensor/sensorturtle/humidity/state",            1, true, String(data_bme.humidity).c_str());
+			mqttClient.publish("homeassistant/sensor/sensorturtle/pressure/state",            1, true, String(data_bme.pressure / 100.0f).c_str());
+			mqttClient.publish("homeassistant/sensor/sensorturtle/gas/state",                 1, true, String(data_bme.gasResistance).c_str());
+			mqttClient.publish("homeassistant/sensor/sensorturtle/iaq/state",                 1, true, String(data_bme.iaq).c_str());
+			mqttClient.publish("homeassistant/sensor/sensorturtle/iaq_accuracy/state",        1, true, String(data_bme.iaqAccuracy).c_str());
+			mqttClient.publish("homeassistant/sensor/sensorturtle/breath_voc/state",          1, true, String(data_bme.breathVocEquivalent).c_str());
+			mqttClient.publish("homeassistant/sensor/sensorturtle/co2_equivalent/state",      1, true, String(data_bme.co2Equivalent).c_str());
+			mqttClient.publish("homeassistant/sensor/sensorturtle/static_iaq_accuracy/state", 1, true, String(data_bme.staticIaqAccuracy).c_str());
+			mqttClient.publish("homeassistant/sensor/sensorturtle/comp_gas_value/state",      1, true, String(data_bme.compGasValue).c_str());
+			mqttClient.publish("homeassistant/sensor/sensorturtle/gas_percentage/state",      1, true, String(data_bme.gasPercentage).c_str());
 
-			mqttClient.publish("sensor/mhz19/accuracy", 1, true, String(data_co2.getAccuracy()).c_str());
-			mqttClient.publish("sensor/mhz19/background", 1, true, String(data_co2.getBackground()).c_str());
-			mqttClient.publish("sensor/mhz19/limited", 1, true, String(data_co2.getLimited()).c_str());
-			mqttClient.publish("sensor/mhz19/raw", 1, true, String(data_co2.getRaw()).c_str());
-			mqttClient.publish("sensor/mhz19/regular", 1, true, String(data_co2.getRegular()).c_str());
-			mqttClient.publish("sensor/mhz19/tempAdjustment", 1, true, String(data_co2.getTempAdjustment()).c_str());
-			mqttClient.publish("sensor/mhz19/temperature", 1, true, String(data_co2.getTemperature()).c_str());
+			// MHZ19
+			mqttClient.publish("homeassistant/sensor/sensorturtle/co2/state",                 1, true, String(data_co2.getRegular()).c_str());
+			mqttClient.publish("homeassistant/sensor/sensorturtle/co2_raw/state",             1, true, String(data_co2.getRaw()).c_str());
+			mqttClient.publish("homeassistant/sensor/sensorturtle/co2_accuracy/state",        1, true, String(data_co2.getAccuracy()).c_str());
+			mqttClient.publish("homeassistant/sensor/sensorturtle/co2_limited/state",         1, true, String(data_co2.getLimited()).c_str());
+			mqttClient.publish("homeassistant/sensor/sensorturtle/co2_background/state",      1, true, String(data_co2.getBackground()).c_str());
+			mqttClient.publish("homeassistant/sensor/sensorturtle/co2_temp_adjustment/state", 1, true, String(data_co2.getTempAdjustment()).c_str());
+			mqttClient.publish("homeassistant/sensor/sensorturtle/co2_temperature/state",     1, true, String(data_co2.getTemperature()).c_str());
 
 #ifdef DEBUG
 			Serial.println("[MQTT] Send data");

--- a/src/MqttClientHandler.h
+++ b/src/MqttClientHandler.h
@@ -19,6 +19,7 @@ public:
 	static void publishData(const DataCO2 co2, const Bsec bme_data, unsigned long currentSeconds);
 	void setup_Mqtt();
 	static bool isConnected();
+	static void publishDiscovery();
 
 private:
 	static void WiFiEvent(WiFiEvent_t event);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -127,6 +127,7 @@ void setup()
 	{
 		MqttClientHandler &MqttHandler = MqttClientHandler::getInstance();
 		MqttHandler.setup_Mqtt();
+		MqttHandler.publishDiscovery();
 	}
 }
 


### PR DESCRIPTION
**Summary**
Fixes the MQTT implementation, adds a dedicated MQTT settings page and implements MQTT Discovery for automatic sensor registration in Home Assistant.
Bug Fixes
fix: MQTT publish condition was inverted (connected == false → true)
fix: duplicate switchMQTT handling removed from settings handler
**Features**
feat: add dedicated MQTT settings page (/mqtt)
feat: add broker configuration (host, port) via web interface
feat: add MQTT credentials management (user, password) via web interface
feat: add MQTT module switch on MQTT settings page
feat: add MQTT connection status indicator (connected / unreachable / not configured)
feat: add /api/mqtt/status endpoint returning JSON connection state
feat: add MQTT Discovery for automatic sensor registration in Home Assistant
feat: add separate HA devices for BME680 (Bosch) and MHZ19 (Winsen)
feat: add isConnected() method to MqttClientHandler
**Refactor**
refactor: MQTT setup reads host, port and credentials from ConfigHandler
refactor: MQTT credentials moved from hardcoded defines to Credentials_example.h
refactor: MQTT_HOST default set to empty string, MQTT_USER_ENABLED default set to 0
refactor: remove disconnectfromMqtt() – connection stays open persistently
refactor: unify MQTT topic naming to lowercase
refactor: topics migrated to homeassistant/sensor/sensorturtle/... schema
refactor: switchMQTT moved from sensor settings page to MQTT settings page
Home Assistant Integration
Device: SensorTurtle BME680 (manufacturer: Bosch, model: BME680)
  - Temperature, Temperature (Offset), Humidity, Air Pressure
  - Gas Resistance, IAQ, IAQ Accuracy, Breath VOC
  - CO2 Equivalent, Static IAQ Accuracy, Comp Gas Value, Gas Percentage

Device: SensorTurtle MHZ19 (manufacturer: Winsen, model: MH-Z19B)
  - CO2, CO2 Raw, CO2 Accuracy, CO2 Limited
  - CO2 Background, CO2 Temp Adjustment, CO2 Temperature
**Notes**
LittleFS filesystem image must be re-uploaded after this PR
ESP32 restart required after changing broker host or port
MQTT Discovery is published once on startup after setup_Mqtt()
HA requires MQTT Integration with discovery enabled (default: on)