### PR TITLE
2610 epd adjustment

### DIFF
--- a/data/static/settings.htm
+++ b/data/static/settings.htm
@@ -21,8 +21,14 @@
 <input type="checkbox" id="switchWIFI" name="switchWIFI" {{switchWIFI_checked}}>
 </div>
 <div class="form-row">
-<label for="switchEPD">EPD Display</label>
-<input type="checkbox" id="switchEPD" name="switchEPD" {{switchEPD_checked}}>
+    <div class="form-row">
+        <label for="switchEPDorientation">EPD Orientation</label>
+        <input type="checkbox" id="switchEPDorientation" name="switchEPDorientation" {{switchEPDorientation_checked}}>
+    </div>
+    <div class="form-row">
+        <label></label>
+        <button type="button" class="btn" id="btnEPDrefresh" style="margin-top:0">Refresh Display</button>
+    </div>
 </div>
 <div class="form-row">
 <label for="switchLED">LED</label>
@@ -107,6 +113,10 @@
 </div>
 <div class="footer">&copy; 2025 SensorTurtle</div>
 <script>
+document.getElementById("btnEPDrefresh").addEventListener("click", function() {
+    fetch("/api/epd/refresh", { method: "POST" })
+    .then(function(r) { showFeedback("feedbackSettings", r.ok); });
+});
 document.addEventListener("DOMContentLoaded",function(){
 function showFeedback(id,ok){
 var el=document.getElementById(id);

--- a/data/static/settings.htm
+++ b/data/static/settings.htm
@@ -21,14 +21,16 @@
 <input type="checkbox" id="switchWIFI" name="switchWIFI" {{switchWIFI_checked}}>
 </div>
 <div class="form-row">
-    <div class="form-row">
-        <label for="switchEPDorientation">EPD Orientation</label>
-        <input type="checkbox" id="switchEPDorientation" name="switchEPDorientation" {{switchEPDorientation_checked}}>
-    </div>
-    <div class="form-row">
-        <label></label>
-        <button type="button" class="btn" id="btnEPDrefresh" style="margin-top:0">Refresh Display</button>
-    </div>
+    <label for="switchEPD">EPD Display</label>
+    <input type="checkbox" id="switchEPD" name="switchEPD" {{switchEPD_checked}}>
+</div>
+<div class="form-row">
+    <label for="switchEPDorientation">EPD Orientation (horizontal)</label>
+    <input type="checkbox" id="switchEPDorientation" name="switchEPDorientation" {{switchEPDorientation_checked}}>
+</div>
+<div class="form-row">
+    <label></label>
+    <button type="button" class="btn" id="btnEPDrefresh">Refresh Display</button>
 </div>
 <div class="form-row">
 <label for="switchLED">LED</label>

--- a/src/ConfigHandler.cpp
+++ b/src/ConfigHandler.cpp
@@ -15,6 +15,7 @@ void ConfigHandler::loadAllPersistedSettings()
 	preferences.begin("config", true);
 		configMapforSwitch["switchWIFI"] = preferences.getBool("switchWIFI", switch_WIFI);
 		configMapforSwitch["switchEPD"] = preferences.getBool("switchEPD", switch_EPD);
+		configMapforSwitch["switchEPDorientation"] = preferences.getBool("switchEPDori", switch_EPD_orientation);
 		configMapforSwitch["switchLED"] = preferences.getBool("switchLED", switch_LED);
 		configMapforSwitch["switchMQTT"] = preferences.getBool("switchMQTT", switch_MQTT);
 
@@ -45,7 +46,7 @@ void ConfigHandler::loadAllPersistedSettings()
 
 void ConfigHandler::validateConfigMaps()
 {
-    for (const auto& key : {"switchWIFI", "switchEPD", "switchLED", "switchMQTT"})
+    for (const auto& key : {"switchWIFI", "switchEPD", "switchEPDorientation", "switchLED", "switchMQTT"})
     {
         if (configMapforSwitch.find(key) == configMapforSwitch.end())
         {
@@ -89,6 +90,7 @@ void ConfigHandler::persistAllSettings()
 	preferences.begin("config", false);
 	preferences.putBool("switchWIFI", configMapforSwitch["switchWIFI"]);
 	preferences.putBool("switchEPD", configMapforSwitch["switchEPD"]);
+	preferences.putBool("switchEPDori", configMapforSwitch["switchEPDorientation"]);
 	preferences.putBool("switchLED", configMapforSwitch["switchLED"]);
 	preferences.putBool("switchMQTT", configMapforSwitch["switchMQTT"]);
 
@@ -125,6 +127,7 @@ void ConfigHandler::restoreDefaultConfiguration()
 
 	preferences.putBool("switchWIFI", switch_WIFI);
 	preferences.putBool("switchEPD", switch_EPD);
+	preferences.putBool("switchEPDori", switch_EPD_orientation);
 	preferences.putBool("switchLED", switch_LED);
 	preferences.putBool("switchMQTT", switch_MQTT);
 

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -9,6 +9,7 @@
 #define switch_EPD 1
 #define switch_LED 1
 #define switch_MQTT 0
+#define switch_EPD_orientation 0 // 0 = vertical, 1 = horizontal
 
 #define interval_MHZ19_in_Seconds 30
 #define interval_BME680_in_Seconds 30

--- a/src/EPDHandler.cpp
+++ b/src/EPDHandler.cpp
@@ -5,277 +5,200 @@
 #include "../font/BabelSans8pt7b.h"
 #include "../font/BabelSans9pt7b.h"
 #include "../font/BabelSans10pt7b.h"
-#include "../font/Inter_Regular12pt7b.h"
-#include "../font/Inter_Regular11pt7b.h"
 #include "../font/Inter_Regular10pt7b.h"
 #include "../font/Inter_Regular8pt7b.h"
-#include "../font/Inter_Regular7pt7b.h"
-
 #include "../font/Inter_Bold12pt7b.h"
-#include "../font/Inter_Bold10pt7b.h"
-
 #include "Configuration.h"
-#include "symbol.h" // own symbol
+#include "symbol.h"
 
 extern ConfigHandler &configHandler;
-unsigned long EPDHandler::_lastRunSeconds = 0;
-#define EPDPrintFormatBufferSize 5
 
-void EPDHandler::printVertically(const DataCO2 co2, const Bsec bme_data, const String &epd_date, const String &epd_time, bool bmeOk)
+#define EPD_FLOAT_BUFFER_SIZE 8  // enough for "-123.4\0"
+
+// Returns GxEPD_RED if value exceeds threshold, otherwise GxEPD_BLACK
+uint16_t EPDHandler::getAlertColor(float value, float threshold)
 {
-	display.init(BAUDRATE);
+    return (value >= threshold) ? GxEPD_RED : GxEPD_BLACK;
+}
 
-	uint16_t color_temp = GxEPD_BLACK;
-	uint16_t color_hum = GxEPD_BLACK;
-	uint16_t color_aiq = GxEPD_BLACK;
-	uint16_t color_co2 = GxEPD_BLACK;
+uint16_t EPDHandler::getAlertColorInt(int value, int threshold)
+{
+    return (value >= threshold) ? GxEPD_RED : GxEPD_BLACK;
+}
 
-	// Lines
-	int16_t line0 = 0;
-	int16_t line1 = 32;
-	int16_t line2 = 104;
+// Prints a single float value at the given position with color
+void EPDHandler::printValue(char *buff, int16_t x, int16_t y, uint16_t color, float value)
+{
+    display.setTextColor(color);
+    display.setCursor(x, y);
+    snprintf(buff, EPD_FLOAT_BUFFER_SIZE, "%.1f", value);
+    display.print(buff);
+}
 
-	// Abstand
-	int16_t ab_temp = 35;
-	int16_t ab_hum = 35 + 45;
-	int16_t ab_iaq = 35 + 45 + 45;
-	int16_t ab_co2 = 35 + 45 + 45 + 45;
+void EPDHandler::printVertically(const DataCO2 &co2, const Bsec &bme_data, const String &epd_date, const String &epd_time, bool bmeOk)
+{
+    display.init(BAUDRATE);
+    display.fillScreen(GxEPD_WHITE);
+    display.setFullWindow();
+    display.setRotation(2);
 
+    const int16_t col0 = 0;
+    const int16_t col1 = 32;
+    const int16_t col2 = 104;
+    const int16_t rowTemp = 35;
+    const int16_t rowHum  = 35 + 45;
+    const int16_t rowIaq  = 35 + 90;
+    const int16_t rowCo2  = 35 + 135;
 
-	if (bme_data.temperature < 26)
-	{
-		color_temp = GxEPD_BLACK;
-	}
-	else
-	{
-		color_temp = GxEPD_RED;
-	}
-	if (bme_data.humidity < 70)
-	{
-		color_hum = GxEPD_BLACK;
-	}
-	else
-	{
-		color_hum = GxEPD_RED;
-	}
-	if (bme_data.iaq < 300)
-	{
-		color_aiq = GxEPD_BLACK;
-	}
-	else
-	{
-		color_aiq = GxEPD_RED;
-	}
-	if (co2.getRegular() < 1500)
-	{
-		color_co2 = GxEPD_BLACK;
-	}
-	else
-	{
-		color_co2 = GxEPD_RED;
-	}
+    uint16_t color_temp = getAlertColor(bme_data.temperature, 26);
+    uint16_t color_hum  = getAlertColor(bme_data.humidity, 70);
+    uint16_t color_aiq  = getAlertColorInt((int)bme_data.iaq, 300);
+    uint16_t color_co2  = getAlertColorInt(co2.getRegular(), 1500);
 
-	display.fillScreen(GxEPD_WHITE); // set the background to white (fill the buffer with value for white)
-	display.setFullWindow();
-	display.setCursor(0, 0);
+    char buffer[EPD_FLOAT_BUFFER_SIZE];
+    display.setFont(&Inter_Bold12pt7b);
 
-	display.setRotation(2); // 0-3
-	char buffer[EPDPrintFormatBufferSize];
-	display.setFont(&Inter_Bold12pt7b);
-
-	if (bmeOk)
+    if (bmeOk)
     {
-        PrintEspLine(buffer, line1, ab_temp, color_temp, bme_data.temperature);
-        display.drawInvertedBitmap(line2 - 1, ab_temp - 10, bitmap_grad18, 18, 18, color_temp);
-        PrintEspLine(buffer, line1, ab_hum, color_hum, bme_data.humidity);
-        PrintEspLine(buffer, line1, ab_iaq, color_aiq, bme_data.iaq);
+        printValue(buffer, col1, rowTemp, color_temp, bme_data.temperature);
+        display.drawInvertedBitmap(col2 - 1, rowTemp - 10, bitmap_grad18, 18, 18, color_temp);
+        printValue(buffer, col1, rowHum, color_hum, bme_data.humidity);
+        printValue(buffer, col1, rowIaq, color_aiq, bme_data.iaq);
     }
     else
     {
         display.setTextColor(GxEPD_BLACK);
-        display.setCursor(line1, ab_temp); display.print("--");
-        display.setCursor(line1, ab_hum);  display.print("--");
-        display.setCursor(line1, ab_iaq);  display.print("--");
+        display.setCursor(col1, rowTemp); display.print("--");
+        display.setCursor(col1, rowHum);  display.print("--");
+        display.setCursor(col1, rowIaq);  display.print("--");
     }
 
-	display.setFont(&Inter_Bold12pt7b);
-	display.setTextColor(color_co2);
-	display.setCursor(line1, ab_co2 + 5);
-	snprintf(buffer, sizeof buffer, "%d", co2.getRegular());
-	display.print(buffer);
+    display.setFont(&Inter_Bold12pt7b);
+    display.setTextColor(color_co2);
+    display.setCursor(col1, rowCo2 + 5);
+    snprintf(buffer, sizeof(buffer), "%d", co2.getRegular());
+    display.print(buffer);
 
-	display.setFont(&Inter_Regular8pt7b);
-	display.setTextColor(color_hum);
-	display.setCursor(line2, ab_hum);
-	display.print("%");
+    display.setFont(&Inter_Regular8pt7b);
+    display.setTextColor(color_hum);
+    display.setCursor(col2, rowHum);
+    display.print("%");
 
-	display.setTextColor(color_aiq);
-	display.setCursor(line2, ab_iaq);
-	display.drawInvertedBitmap(line2, ab_iaq - 10, bitmap_iaq, 18, 18, color_aiq);
-	display.drawInvertedBitmap(line2, ab_co2 - 10, bitmap_ppm18, 18, 18, color_co2);
-	display.drawInvertedBitmap(line0, ab_temp - 20, bitmap_temp, 24, 24, color_temp);
-	display.drawInvertedBitmap(line0, ab_hum - 20, bitmap_hum, 24, 24, color_hum);
-	display.drawInvertedBitmap(line0, ab_iaq - 20, bitmap_aiq, 24, 24, color_aiq);
-	display.drawInvertedBitmap(line0, ab_co2 - 14, bitmap_CO2, 24, 24, color_co2);
+    display.drawInvertedBitmap(col2,  rowIaq - 10,  bitmap_iaq,   18, 18, color_aiq);
+    display.drawInvertedBitmap(col2,  rowCo2 - 10,  bitmap_ppm18, 18, 18, color_co2);
+    display.drawInvertedBitmap(col0,  rowTemp - 20, bitmap_temp,  24, 24, color_temp);
+    display.drawInvertedBitmap(col0,  rowHum - 20,  bitmap_hum,   24, 24, color_hum);
+    display.drawInvertedBitmap(col0,  rowIaq - 20,  bitmap_aiq,   24, 24, color_aiq);
+    display.drawInvertedBitmap(col0,  rowCo2 - 14,  bitmap_CO2,   24, 24, color_co2);
 
-	display.setRotation(2); // 0-3
-	display.setTextColor(GxEPD_BLACK);
+    display.setRotation(2);
+    display.setTextColor(GxEPD_BLACK);
+    display.setFont(&BabelSans8pt7b);
+    display.setCursor(col0, 228);
+    display.print(epd_date);
 
-	display.setFont(&BabelSans8pt7b);
-	display.setCursor(line0, 228);
-	display.print(epd_date);
+    display.setFont(&BabelSans10pt7b);
+    display.setCursor(col0 + 80, 228);
+    display.print(epd_time);
 
-	display.setFont(&BabelSans10pt7b);
-	display.setCursor(line0 + 80, 228);
-	display.print(epd_time);
+    display.setFont(&BabelSans8pt7b);
+    display.setCursor(col0 + 20, 248);
+    display.print(DeviceName);
+    display.drawInvertedBitmap(col0, 248 - 14, bitmap_turtle, 18, 18, GxEPD_RED);
 
-	display.setFont(&BabelSans8pt7b);
-	display.setCursor(line0 + 20, 248);
-	display.print(DeviceName);
-	display.drawInvertedBitmap(line0, 248 - 14, bitmap_turtle, 18, 18, GxEPD_RED);
-
-	display.hibernate();
-	display.display(false);
-	display.end();
+    display.display(false);
+    display.hibernate();
+    display.end();
 }
 
-void EPDHandler::printHorizontally(const DataCO2 co2, const Bsec bme_data, const String &epd_date, const String &epd_time, bool bmeOk)
+void EPDHandler::printHorizontally(const DataCO2 &co2, const Bsec &bme_data, const String &epd_date, const String &epd_time, bool bmeOk)
 {
-	display.init(BAUDRATE);
+    display.init(BAUDRATE);
+    display.fillScreen(GxEPD_WHITE);
+    display.setFullWindow();
+    display.setRotation(1);
 
-	uint16_t color_temp = GxEPD_BLACK;
-	uint16_t color_hum = GxEPD_BLACK;
-	uint16_t color_aiq = GxEPD_BLACK;
-	uint16_t color_co2 = GxEPD_BLACK;
+    const int col1 = 30;
+    const int col2 = 90;
+    const int rowTemp = 20;
+    const int rowHum  = 52;
+    const int rowIaq  = 86;
+    const int rowCo2  = 115;
 
-	// Lines
-	int line1 = 30;
-	int line2 = 90;
+    uint16_t color_temp = getAlertColor(bme_data.temperature, 26);
+    uint16_t color_hum  = getAlertColor(bme_data.humidity, 70);
+    uint16_t color_aiq  = getAlertColorInt((int)bme_data.iaq, 300);
+    uint16_t color_co2  = getAlertColorInt(co2.getRegular(), 1500);
 
-	// Abstand
-	int ab_temp = 20;
-	int ab_hum = 52;
-	int ab_iaq = 86;
-	int ab_co2 = 115;
+    char buffer[EPD_FLOAT_BUFFER_SIZE];
+    display.setFont(&Inter_Bold12pt7b);
 
-	// Limit
-	if (bme_data.temperature < 26)
-	{
-		color_temp = GxEPD_BLACK;
-	}
-	else
-	{
-		color_temp = GxEPD_RED;
-	}
-	if (bme_data.humidity < 70)
-	{
-		color_hum = GxEPD_BLACK;
-	}
-	else
-	{
-		color_hum = GxEPD_RED;
-	}
-	if (bme_data.iaq < 300)
-	{
-		color_aiq = GxEPD_BLACK;
-	}
-	else
-	{
-		color_aiq = GxEPD_RED;
-	}
-	if (co2.getRegular() < 1500)
-	{
-		color_co2 = GxEPD_BLACK;
-	}
-	else
-	{
-		color_co2 = GxEPD_RED;
-	}
-
-	display.fillScreen(GxEPD_WHITE); // set the background to white (fill the buffer with value for white)
-	display.setFullWindow();
-	display.setCursor(0, 0);
-
-	display.setRotation(1); // 0-3
-	char buffer[EPDPrintFormatBufferSize];
-	display.setFont(&Inter_Bold12pt7b);
-
-	if (bmeOk)
+    if (bmeOk)
     {
-        PrintEspLine(buffer, line1, ab_temp, color_temp, bme_data.temperature);
-        PrintEspLine(buffer, line1, ab_hum, color_hum, bme_data.humidity);
-        PrintEspLine(buffer, line1, ab_iaq, color_aiq, bme_data.staticIaq);
+        printValue(buffer, col1, rowTemp, color_temp, bme_data.temperature);
+        printValue(buffer, col1, rowHum,  color_hum,  bme_data.humidity);
+        printValue(buffer, col1, rowIaq,  color_aiq,  bme_data.staticIaq);
     }
     else
     {
         display.setTextColor(GxEPD_BLACK);
-        display.setCursor(line1, ab_temp); display.print("--");
-        display.setCursor(line1, ab_hum);  display.print("--");
-        display.setCursor(line1, ab_iaq);  display.print("--");
+        display.setCursor(col1, rowTemp); display.print("--");
+        display.setCursor(col1, rowHum);  display.print("--");
+        display.setCursor(col1, rowIaq);  display.print("--");
     }
 
-	display.setFont(&Inter_Bold12pt7b);
-	display.setTextColor(color_co2);
-	display.setCursor(line1, ab_co2 + 5);
-	snprintf(buffer, sizeof buffer, "%d", co2.getRegular());
-	display.print(buffer);
+    display.setFont(&Inter_Bold12pt7b);
+    display.setTextColor(color_co2);
+    display.setCursor(col1, rowCo2 + 5);
+    snprintf(buffer, sizeof(buffer), "%d", co2.getRegular());
+    display.print(buffer);
 
-	display.setFont(&Inter_Regular10pt7b);
+    display.setFont(&Inter_Regular10pt7b);
+    display.setTextColor(color_hum);
+    display.setCursor(col2, rowHum);
+    display.print(" %");
 
-	display.setTextColor(color_hum);
-	display.setCursor(line2, ab_hum);
-	display.print(" %");
+    display.drawInvertedBitmap(col2 + 5, rowIaq  - 10, bitmap_iaq,   18, 18, color_aiq);
+    display.drawInvertedBitmap(col2 + 5, rowCo2  - 10, bitmap_ppm18, 18, 18, color_co2);
+    display.drawInvertedBitmap(col2 + 5, rowTemp - 20, bitmap_grad,  24, 24, color_temp);
+    display.drawInvertedBitmap(0, rowTemp - 20, bitmap_temp, 24, 24, color_temp);
+    display.drawInvertedBitmap(0, rowHum  - 20, bitmap_hum,  24, 24, color_hum);
+    display.drawInvertedBitmap(0, rowIaq  - 20, bitmap_aiq,  24, 24, color_aiq);
+    display.drawInvertedBitmap(0, rowCo2  - 14, bitmap_CO2,  24, 24, color_co2);
 
-	display.drawInvertedBitmap(line2 + 5, ab_iaq - 10, bitmap_iaq, 18, 18, color_aiq);
-	display.drawInvertedBitmap(line2 + 5, ab_co2 - 10, bitmap_ppm18, 18, 18, color_co2);
-	display.drawInvertedBitmap(line2 + 5, ab_temp - 20, bitmap_grad, 24, 24, color_temp);
-	display.drawInvertedBitmap(0, ab_temp - 20, bitmap_temp, 24, 24, color_temp);
-	display.drawInvertedBitmap(0, ab_hum - 20, bitmap_hum, 24, 24, color_hum);
-	display.drawInvertedBitmap(0, ab_iaq - 20, bitmap_aiq, 24, 24, color_aiq);
-	display.drawInvertedBitmap(0, ab_co2 - 14, bitmap_CO2, 24, 24, color_co2);
+    display.setRotation(1);
+    display.setFont(&BabelSans9pt7b);
+    display.setTextColor(GxEPD_BLACK);
+    display.setCursor(140, 14);
+    display.print(epd_time);
+    display.setCursor(200, 14);
+    display.print(epd_date);
+    display.setCursor(140 + 20, 32);
+    display.setFont(&BabelSans8pt7b);
+    display.print(DeviceName);
+    display.drawInvertedBitmap(140, 32 - 14, bitmap_turtle, 18, 18, GxEPD_RED);
 
-	display.setRotation(1); // 0-3
-	display.setFont(&BabelSans9pt7b);
-	display.setTextColor(GxEPD_BLACK);
-	display.setCursor(140, 14);
-	display.print(epd_time);
-
-	display.setFont(&BabelSans9pt7b);
-	display.setTextColor(GxEPD_BLACK);
-	display.setCursor(200, 14);
-	display.print(epd_date);
-
-	display.setCursor(140 + 20, 32);
-	display.setFont(&BabelSans8pt7b);
-	display.print(DeviceName);
-	display.drawInvertedBitmap(140, 32 - 14, bitmap_turtle, 18, 18, GxEPD_RED);
-
-	display.display(false);
-	display.hibernate();
+    display.display(false);
+    display.hibernate();
+    display.end();
 }
 
-void EPDHandler::updateEPDvertical(const DataCO2 co2, const Bsec bme_data, const String &epd_date, const String &epd_time, const unsigned long currentSeconds)
+void EPDHandler::updateEPD(const DataCO2 &co2, const Bsec &bme_data, const String &epd_date, const String &epd_time, unsigned long currentSeconds)
 {
-	if (currentSeconds - _lastRunSeconds >= (unsigned long)configHandler.getConfigInterval("intervalEPD"))
-	{
-		_lastRunSeconds = currentSeconds;
-		printVertically(co2, bme_data, epd_date, epd_time, BME680Handler::getInstance().isSensorOk());
-	}
+    if (currentSeconds - _lastRunSeconds < (unsigned long)configHandler.getConfigInterval("intervalEPD"))
+        return;
+
+    _lastRunSeconds = currentSeconds;
+    bool bmeOk = BME680Handler::getInstance().isSensorOk();
+    bool horizontal = configHandler.getConfigSwitch("switchEPDorientation");
+
+    if (horizontal)
+        printHorizontally(co2, bme_data, epd_date, epd_time, bmeOk);
+    else
+        printVertically(co2, bme_data, epd_date, epd_time, bmeOk);
 }
 
-void EPDHandler::updateEPDhorizontal(const DataCO2 co2, const Bsec bme_data, const String &epd_date, const String &epd_time, const unsigned long currentSeconds)
+void EPDHandler::forceRefresh()
 {
-	if (currentSeconds - _lastRunSeconds >= (unsigned long)configHandler.getConfigInterval("intervalEPD"))
-	{
-		_lastRunSeconds = currentSeconds;
-		printHorizontally(co2, bme_data, epd_date, epd_time, BME680Handler::getInstance().isSensorOk());
-	}
-}
-
-void EPDHandler::PrintEspLine(char *buff, int16_t cursorX, int16_t cursorY, uint16_t color, float toPrint)
-{
-	display.setTextColor(color);
-	display.setCursor(cursorX, cursorY);
-	snprintf(buff, EPDPrintFormatBufferSize, "%f", toPrint);
-	display.print(buff);
+    _lastRunSeconds = 0;
 }

--- a/src/EPDHandler.cpp
+++ b/src/EPDHandler.cpp
@@ -81,8 +81,8 @@ void EPDHandler::printLayout(const DataCO2 &co2, const Bsec &bme_data, const Str
 
     uint16_t color_temp = getAlertColor(bme_data.temperature, 26);
     uint16_t color_hum  = getAlertColor(bme_data.humidity, 70);
-    uint16_t color_aiq  = getAlertColorInt((int)bme_data.iaq, 300);
-    uint16_t color_co2  = getAlertColorInt(co2.getRegular(), 1500);
+    uint16_t color_iaq = getAlertColor(bme_data.iaq, 300);
+    uint16_t color_co2 = getAlertColor(co2.getRegular(), 1500);
 
     char buffer[EPD_FLOAT_BUFFER_SIZE];
     display.setFont(&Inter_Bold12pt7b);
@@ -113,7 +113,7 @@ void EPDHandler::printLayout(const DataCO2 &co2, const Bsec &bme_data, const Str
 
     // Right column icons
     display.drawInvertedBitmap(l.colR_icon, l.rowTop - 20, bitmap_CO2, 24, 24, color_co2);
-    display.drawInvertedBitmap(l.colR_icon, l.rowBot - 20, bitmap_aiq, 24, 24, color_aiq);
+    display.drawInvertedBitmap(l.colR_icon, l.rowBot - 20, bitmap_aiq, 24, 24, color_iaq);
 
     // Right column values: CO2 (top), IAQ (bottom)
     display.setFont(&Inter_Bold12pt7b);
@@ -122,10 +122,10 @@ void EPDHandler::printLayout(const DataCO2 &co2, const Bsec &bme_data, const Str
     snprintf(buffer, sizeof(buffer), "%d", co2.getRegular());
     display.print(buffer);
     display.drawInvertedBitmap(l.colR_unit, l.rowTop - 16, bitmap_ppm18, 18, 18, color_co2);
-    display.drawInvertedBitmap(l.colR_unit, l.rowBot - 16, bitmap_iaq, 18, 18, color_aiq);
+    display.drawInvertedBitmap(l.colR_unit, l.rowBot - 16, bitmap_iaq, 18, 18, color_iaq);
 
     if (bmeOk)
-        printValue(buffer, l.colR_value, l.rowBot, color_aiq, bme_data.staticIaq);
+        printValue(buffer, l.colR_value, l.rowBot, color_iaq, bme_data.staticIaq);
     else
     {
         display.setTextColor(GxEPD_BLACK);

--- a/src/EPDHandler.cpp
+++ b/src/EPDHandler.cpp
@@ -200,5 +200,18 @@ void EPDHandler::updateEPD(const DataCO2 &co2, const Bsec &bme_data, const Strin
 
 void EPDHandler::forceRefresh()
 {
-    _lastRunSeconds = 0;
+    // Set to a value that guarantees immediate update on next loop
+    _lastRunSeconds = ULONG_MAX - (unsigned long)configHandler.getConfigInterval("intervalEPD") - 1;
+}
+
+void EPDHandler::clearDisplay()
+{
+    display.init(BAUDRATE);
+    display.fillScreen(GxEPD_WHITE);
+    display.setFullWindow();
+    display.setRotation(2);
+    display.drawInvertedBitmap(0, 248 - 14, bitmap_turtle, 18, 18, GxEPD_RED);
+    display.display(false);
+    display.hibernate();
+    display.end();
 }

--- a/src/EPDHandler.cpp
+++ b/src/EPDHandler.cpp
@@ -15,7 +15,6 @@ extern ConfigHandler &configHandler;
 
 #define EPD_FLOAT_BUFFER_SIZE 8  // enough for "-123.4\0"
 
-// Returns GxEPD_RED if value exceeds threshold, otherwise GxEPD_BLACK
 uint16_t EPDHandler::getAlertColor(float value, float threshold)
 {
     return (value >= threshold) ? GxEPD_RED : GxEPD_BLACK;
@@ -26,7 +25,6 @@ uint16_t EPDHandler::getAlertColorInt(int value, int threshold)
     return (value >= threshold) ? GxEPD_RED : GxEPD_BLACK;
 }
 
-// Prints a single float value at the given position with color
 void EPDHandler::printValue(char *buff, int16_t x, int16_t y, uint16_t color, float value)
 {
     display.setTextColor(color);
@@ -35,95 +33,50 @@ void EPDHandler::printValue(char *buff, int16_t x, int16_t y, uint16_t color, fl
     display.print(buff);
 }
 
-void EPDHandler::printVertically(const DataCO2 &co2, const Bsec &bme_data, const String &epd_date, const String &epd_time, bool bmeOk)
+EPDLayout EPDHandler::verticalLayout()
 {
-    display.init(BAUDRATE);
-    display.fillScreen(GxEPD_WHITE);
-    display.setFullWindow();
-    display.setRotation(2);
-
-    const int16_t col0 = 0;
-    const int16_t col1 = 32;
-    const int16_t col2 = 104;
-    const int16_t rowTemp = 35;
-    const int16_t rowHum  = 35 + 45;
-    const int16_t rowIaq  = 35 + 90;
-    const int16_t rowCo2  = 35 + 135;
-
-    uint16_t color_temp = getAlertColor(bme_data.temperature, 26);
-    uint16_t color_hum  = getAlertColor(bme_data.humidity, 70);
-    uint16_t color_aiq  = getAlertColorInt((int)bme_data.iaq, 300);
-    uint16_t color_co2  = getAlertColorInt(co2.getRegular(), 1500);
-
-    char buffer[EPD_FLOAT_BUFFER_SIZE];
-    display.setFont(&Inter_Bold12pt7b);
-
-    if (bmeOk)
-    {
-        printValue(buffer, col1, rowTemp, color_temp, bme_data.temperature);
-        display.drawInvertedBitmap(col2 - 1, rowTemp - 10, bitmap_grad18, 18, 18, color_temp);
-        printValue(buffer, col1, rowHum, color_hum, bme_data.humidity);
-        printValue(buffer, col1, rowIaq, color_aiq, bme_data.iaq);
-    }
-    else
-    {
-        display.setTextColor(GxEPD_BLACK);
-        display.setCursor(col1, rowTemp); display.print("--");
-        display.setCursor(col1, rowHum);  display.print("--");
-        display.setCursor(col1, rowIaq);  display.print("--");
-    }
-
-    display.setFont(&Inter_Bold12pt7b);
-    display.setTextColor(color_co2);
-    display.setCursor(col1, rowCo2 + 5);
-    snprintf(buffer, sizeof(buffer), "%d", co2.getRegular());
-    display.print(buffer);
-
-    display.setFont(&Inter_Regular8pt7b);
-    display.setTextColor(color_hum);
-    display.setCursor(col2, rowHum);
-    display.print("%");
-
-    display.drawInvertedBitmap(col2,  rowIaq - 10,  bitmap_iaq,   18, 18, color_aiq);
-    display.drawInvertedBitmap(col2,  rowCo2 - 10,  bitmap_ppm18, 18, 18, color_co2);
-    display.drawInvertedBitmap(col0,  rowTemp - 20, bitmap_temp,  24, 24, color_temp);
-    display.drawInvertedBitmap(col0,  rowHum - 20,  bitmap_hum,   24, 24, color_hum);
-    display.drawInvertedBitmap(col0,  rowIaq - 20,  bitmap_aiq,   24, 24, color_aiq);
-    display.drawInvertedBitmap(col0,  rowCo2 - 14,  bitmap_CO2,   24, 24, color_co2);
-
-    display.setRotation(2);
-    display.setTextColor(GxEPD_BLACK);
-    display.setFont(&BabelSans8pt7b);
-    display.setCursor(col0, 228);
-    display.print(epd_date);
-
-    display.setFont(&BabelSans10pt7b);
-    display.setCursor(col0 + 80, 228);
-    display.print(epd_time);
-
-    display.setFont(&BabelSans8pt7b);
-    display.setCursor(col0 + 20, 248);
-    display.print(DeviceName);
-    display.drawInvertedBitmap(col0, 248 - 14, bitmap_turtle, 18, 18, GxEPD_RED);
-
-    display.display(false);
-    display.hibernate();
-    display.end();
+    EPDLayout l;
+    l.rotation    = 2;
+    l.colL_icon   = 0;
+    l.colL_value  = 32;
+    l.colL_unit   = 104;
+    l.colR_icon   = 0;
+    l.colR_value  = 32;
+    l.colR_unit   = 104;
+    l.rowTop      = 35;
+    l.rowBot      = 80;
+    l.footerTurtleX = 0;   l.footerTurtleY = 234;
+    l.footerDateX   = 0;   l.footerDateY   = 228;
+    l.footerTimeX   = 80;  l.footerTimeY   = 228;
+    l.footerNameX   = 20;  l.footerNameY   = 248;
+    return l;
 }
 
-void EPDHandler::printHorizontally(const DataCO2 &co2, const Bsec &bme_data, const String &epd_date, const String &epd_time, bool bmeOk)
+EPDLayout EPDHandler::horizontalLayout()
+{
+    EPDLayout l;
+    l.rotation    = 1;
+    l.colL_icon   = 0;
+    l.colL_value  = 30;
+    l.colL_unit   = 95;
+    l.colR_icon   = 130;
+    l.colR_value  = 160;
+    l.colR_unit   = 200;
+    l.rowTop      = 20;
+    l.rowBot      = 52;
+    l.footerTurtleX = 2;   l.footerTurtleY = 104;
+    l.footerDateX   = 2;   l.footerDateY   = 100;
+    l.footerTimeX   = 50;  l.footerTimeY   = 100;
+    l.footerNameX   = 22;  l.footerNameY   = 118;
+    return l;
+}
+
+void EPDHandler::printLayout(const DataCO2 &co2, const Bsec &bme_data, const String &epd_date, const String &epd_time, bool bmeOk, const EPDLayout &l)
 {
     display.init(BAUDRATE);
     display.fillScreen(GxEPD_WHITE);
     display.setFullWindow();
-    display.setRotation(1);
-
-    const int col1 = 30;
-    const int col2 = 90;
-    const int rowTemp = 20;
-    const int rowHum  = 52;
-    const int rowIaq  = 86;
-    const int rowCo2  = 115;
+    display.setRotation(l.rotation);
 
     uint16_t color_temp = getAlertColor(bme_data.temperature, 26);
     uint16_t color_hum  = getAlertColor(bme_data.humidity, 70);
@@ -133,50 +86,62 @@ void EPDHandler::printHorizontally(const DataCO2 &co2, const Bsec &bme_data, con
     char buffer[EPD_FLOAT_BUFFER_SIZE];
     display.setFont(&Inter_Bold12pt7b);
 
+    // Left column icons
+    display.drawInvertedBitmap(l.colL_icon, l.rowTop - 20, bitmap_temp, 24, 24, color_temp);
+    display.drawInvertedBitmap(l.colL_icon, l.rowBot - 20, bitmap_hum,  24, 24, color_hum);
+
+    // Left column values: Temperature (top), Humidity (bottom)
     if (bmeOk)
     {
-        printValue(buffer, col1, rowTemp, color_temp, bme_data.temperature);
-        printValue(buffer, col1, rowHum,  color_hum,  bme_data.humidity);
-        printValue(buffer, col1, rowIaq,  color_aiq,  bme_data.staticIaq);
+        printValue(buffer, l.colL_value, l.rowTop, color_temp, bme_data.temperature);
+        printValue(buffer, l.colL_value, l.rowBot, color_hum,  bme_data.humidity);
     }
     else
     {
         display.setTextColor(GxEPD_BLACK);
-        display.setCursor(col1, rowTemp); display.print("--");
-        display.setCursor(col1, rowHum);  display.print("--");
-        display.setCursor(col1, rowIaq);  display.print("--");
+        display.setCursor(l.colL_value, l.rowTop); display.print("--");
+        display.setCursor(l.colL_value, l.rowBot); display.print("--");
     }
 
-    display.setFont(&Inter_Bold12pt7b);
-    display.setTextColor(color_co2);
-    display.setCursor(col1, rowCo2 + 5);
-    snprintf(buffer, sizeof(buffer), "%d", co2.getRegular());
-    display.print(buffer);
-
+    // Left column units
+    display.drawInvertedBitmap(l.colL_unit, l.rowTop - 16, bitmap_grad18, 18, 18, color_temp);
     display.setFont(&Inter_Regular10pt7b);
     display.setTextColor(color_hum);
-    display.setCursor(col2, rowHum);
-    display.print(" %");
+    display.setCursor(l.colL_unit, l.rowBot);
+    display.print("%");
 
-    display.drawInvertedBitmap(col2 + 5, rowIaq  - 10, bitmap_iaq,   18, 18, color_aiq);
-    display.drawInvertedBitmap(col2 + 5, rowCo2  - 10, bitmap_ppm18, 18, 18, color_co2);
-    display.drawInvertedBitmap(col2 + 5, rowTemp - 20, bitmap_grad,  24, 24, color_temp);
-    display.drawInvertedBitmap(0, rowTemp - 20, bitmap_temp, 24, 24, color_temp);
-    display.drawInvertedBitmap(0, rowHum  - 20, bitmap_hum,  24, 24, color_hum);
-    display.drawInvertedBitmap(0, rowIaq  - 20, bitmap_aiq,  24, 24, color_aiq);
-    display.drawInvertedBitmap(0, rowCo2  - 14, bitmap_CO2,  24, 24, color_co2);
+    // Right column icons
+    display.drawInvertedBitmap(l.colR_icon, l.rowTop - 20, bitmap_CO2, 24, 24, color_co2);
+    display.drawInvertedBitmap(l.colR_icon, l.rowBot - 20, bitmap_aiq, 24, 24, color_aiq);
 
-    display.setRotation(1);
-    display.setFont(&BabelSans9pt7b);
-    display.setTextColor(GxEPD_BLACK);
-    display.setCursor(140, 14);
-    display.print(epd_time);
-    display.setCursor(200, 14);
-    display.print(epd_date);
-    display.setCursor(140 + 20, 32);
+    // Right column values: CO2 (top), IAQ (bottom)
+    display.setFont(&Inter_Bold12pt7b);
+    display.setTextColor(color_co2);
+    display.setCursor(l.colR_value, l.rowTop);
+    snprintf(buffer, sizeof(buffer), "%d", co2.getRegular());
+    display.print(buffer);
+    display.drawInvertedBitmap(l.colR_unit, l.rowTop - 16, bitmap_ppm18, 18, 18, color_co2);
+
+    if (bmeOk)
+        printValue(buffer, l.colR_value, l.rowBot, color_aiq, bme_data.staticIaq);
+    else
+    {
+        display.setTextColor(GxEPD_BLACK);
+        display.setCursor(l.colR_value, l.rowBot); display.print("--");
+    }
+
+    // Footer
+    display.drawInvertedBitmap(l.footerTurtleX, l.footerTurtleY, bitmap_turtle, 18, 18, GxEPD_RED);
     display.setFont(&BabelSans8pt7b);
+    display.setTextColor(GxEPD_BLACK);
+    display.setCursor(l.footerDateX, l.footerDateY);
+    display.print(epd_date);
+    display.setFont(&BabelSans9pt7b);
+    display.setCursor(l.footerTimeX, l.footerTimeY);
+    display.print(epd_time);
+    display.setFont(&BabelSans8pt7b);
+    display.setCursor(l.footerNameX, l.footerNameY);
     display.print(DeviceName);
-    display.drawInvertedBitmap(140, 32 - 14, bitmap_turtle, 18, 18, GxEPD_RED);
 
     display.display(false);
     display.hibernate();
@@ -190,12 +155,11 @@ void EPDHandler::updateEPD(const DataCO2 &co2, const Bsec &bme_data, const Strin
 
     _lastRunSeconds = currentSeconds;
     bool bmeOk = BME680Handler::getInstance().isSensorOk();
-    bool horizontal = configHandler.getConfigSwitch("switchEPDorientation");
+    EPDLayout layout = configHandler.getConfigSwitch("switchEPDorientation")
+        ? horizontalLayout()
+        : verticalLayout();
 
-    if (horizontal)
-        printHorizontally(co2, bme_data, epd_date, epd_time, bmeOk);
-    else
-        printVertically(co2, bme_data, epd_date, epd_time, bmeOk);
+    printLayout(co2, bme_data, epd_date, epd_time, bmeOk, layout);
 }
 
 void EPDHandler::forceRefresh()

--- a/src/EPDHandler.cpp
+++ b/src/EPDHandler.cpp
@@ -58,15 +58,16 @@ EPDLayout EPDHandler::horizontalLayout()
     l.rotation    = 1;
     l.colL_icon   = 0;
     l.colL_value  = 30;
-    l.colL_unit   = 95;
+    l.colL_unit   = 90;
+
     l.colR_icon   = 130;
     l.colR_value  = 160;
-    l.colR_unit   = 200;
+    l.colR_unit   = 225;
     l.rowTop      = 20;
     l.rowBot      = 52;
     l.footerTurtleX = 2;   l.footerTurtleY = 104;
     l.footerDateX   = 2;   l.footerDateY   = 100;
-    l.footerTimeX   = 50;  l.footerTimeY   = 100;
+    l.footerTimeX   = 70;  l.footerTimeY   = 100;
     l.footerNameX   = 22;  l.footerNameY   = 118;
     return l;
 }
@@ -121,6 +122,7 @@ void EPDHandler::printLayout(const DataCO2 &co2, const Bsec &bme_data, const Str
     snprintf(buffer, sizeof(buffer), "%d", co2.getRegular());
     display.print(buffer);
     display.drawInvertedBitmap(l.colR_unit, l.rowTop - 16, bitmap_ppm18, 18, 18, color_co2);
+    display.drawInvertedBitmap(l.colR_unit, l.rowBot - 16, bitmap_iaq, 18, 18, color_aiq);
 
     if (bmeOk)
         printValue(buffer, l.colR_value, l.rowBot, color_aiq, bme_data.staticIaq);

--- a/src/EPDHandler.h
+++ b/src/EPDHandler.h
@@ -8,21 +8,29 @@
 class EPDHandler
 {
 public:
-	static EPDHandler &getInstance()
-	{
-		static EPDHandler instance;
-		return instance;
-	}
-	static void updateEPDvertical(DataCO2 co2, Bsec data, const String &epd_date, const String &epd_time, unsigned long currentSeconds);
-	static void updateEPDhorizontal(DataCO2 co2, Bsec data, const String &epd_date, const String &epd_time, unsigned long currentSeconds);
+    static EPDHandler &getInstance()
+    {
+        static EPDHandler instance;
+        return instance;
+    }
+
+    void updateEPD(const DataCO2 &co2, const Bsec &bme_data, const String &epd_date, const String &epd_time, unsigned long currentSeconds);
+    void forceRefresh();
 
 private:
-	static void printVertically(DataCO2 co2, Bsec bme_data, const String &epd_date, const String &epd_time, bool bmeOk);
-	static void printHorizontally(DataCO2 co2, Bsec bme_data, const String &epd_date, const String &epd_time, bool bmeOk);
-	EPDHandler() {};
-	EPDHandler(EPDHandler const &);
-	void operator=(EPDHandler const &);
-	static void PrintEspLine(char *buff, int16_t cursorX, int16_t cursorY, uint16_t color, float toPrint);
-	static unsigned long _lastRunSeconds;
+    EPDHandler() {};
+    EPDHandler(EPDHandler const &);
+    void operator=(EPDHandler const &);
+
+    void printVertically(const DataCO2 &co2, const Bsec &bme_data, const String &epd_date, const String &epd_time, bool bmeOk);
+    void printHorizontally(const DataCO2 &co2, const Bsec &bme_data, const String &epd_date, const String &epd_time, bool bmeOk);
+    void printSensorValues(const DataCO2 &co2, const Bsec &bme_data, bool bmeOk, int16_t col1, int16_t col2, int16_t rowTemp, int16_t rowHum, int16_t rowIaq, int16_t rowCo2);
+    void printValue(char *buff, int16_t x, int16_t y, uint16_t color, float value);
+
+    static uint16_t getAlertColor(float value, float threshold);
+    static uint16_t getAlertColorInt(int value, int threshold);
+
+    unsigned long _lastRunSeconds = 0;
 };
+
 #endif // CO2_TURTLE_EPDHANDLER_H

--- a/src/EPDHandler.h
+++ b/src/EPDHandler.h
@@ -16,6 +16,7 @@ public:
 
     void updateEPD(const DataCO2 &co2, const Bsec &bme_data, const String &epd_date, const String &epd_time, unsigned long currentSeconds);
     void forceRefresh();
+	void clearDisplay();
 
 private:
     EPDHandler() {};
@@ -24,7 +25,6 @@ private:
 
     void printVertically(const DataCO2 &co2, const Bsec &bme_data, const String &epd_date, const String &epd_time, bool bmeOk);
     void printHorizontally(const DataCO2 &co2, const Bsec &bme_data, const String &epd_date, const String &epd_time, bool bmeOk);
-    void printSensorValues(const DataCO2 &co2, const Bsec &bme_data, bool bmeOk, int16_t col1, int16_t col2, int16_t rowTemp, int16_t rowHum, int16_t rowIaq, int16_t rowCo2);
     void printValue(char *buff, int16_t x, int16_t y, uint16_t color, float value);
 
     static uint16_t getAlertColor(float value, float threshold);

--- a/src/EPDHandler.h
+++ b/src/EPDHandler.h
@@ -5,6 +5,33 @@
 #include "bsec.h"
 #include "BME680Handler.h"
 
+struct EPDLayout
+{
+    int rotation;
+
+    // Sensor value columns
+    int colL_icon;
+    int colL_value;
+    int colL_unit;
+    int colR_icon;
+    int colR_value;
+    int colR_unit;
+
+    // Sensor rows
+    int rowTop;
+    int rowBot;
+
+    // Footer
+    int footerTurtleX;
+    int footerTurtleY;
+    int footerDateX;
+    int footerDateY;
+    int footerTimeX;
+    int footerTimeY;
+    int footerNameX;
+    int footerNameY;
+};
+
 class EPDHandler
 {
 public:
@@ -16,17 +43,18 @@ public:
 
     void updateEPD(const DataCO2 &co2, const Bsec &bme_data, const String &epd_date, const String &epd_time, unsigned long currentSeconds);
     void forceRefresh();
-	void clearDisplay();
+    void clearDisplay();
 
 private:
     EPDHandler() {};
     EPDHandler(EPDHandler const &);
     void operator=(EPDHandler const &);
 
-    void printVertically(const DataCO2 &co2, const Bsec &bme_data, const String &epd_date, const String &epd_time, bool bmeOk);
-    void printHorizontally(const DataCO2 &co2, const Bsec &bme_data, const String &epd_date, const String &epd_time, bool bmeOk);
+    void printLayout(const DataCO2 &co2, const Bsec &bme_data, const String &epd_date, const String &epd_time, bool bmeOk, const EPDLayout &layout);
     void printValue(char *buff, int16_t x, int16_t y, uint16_t color, float value);
 
+    static EPDLayout verticalLayout();
+    static EPDLayout horizontalLayout();
     static uint16_t getAlertColor(float value, float threshold);
     static uint16_t getAlertColorInt(int value, int threshold);
 

--- a/src/WebServerHandler.cpp
+++ b/src/WebServerHandler.cpp
@@ -7,6 +7,7 @@
 #include "MqttClientHandler.h"
 #include "LEDHandler.h"
 #include "BME680Handler.h"
+#include "EPDHandler.h"
 extern ConfigHandler &configHandler;
 
 WebServerHandler::WebServerHandler()
@@ -43,6 +44,8 @@ void WebServerHandler::start()
 	server.on("/submitMQTTconfig", HTTP_POST, [this](AsyncWebServerRequest *request) {handle_submit_mqttconfig(request); });
 	server.on("/api/mqtt/status", HTTP_GET, [this](AsyncWebServerRequest *request) {handle_api_mqtt_status(request); });
 	server.on("/api/system/status", HTTP_GET, [this](AsyncWebServerRequest *request) {handle_api_system_status(request); });
+
+	server.on("/api/epd/refresh", HTTP_POST, [this](AsyncWebServerRequest *request) {EPDHandler::getInstance().forceRefresh(); request->send(200, "text/plain", "ok");});
 
 	server.onNotFound(handle_page_NotFound);
 	server.begin();
@@ -229,6 +232,7 @@ void WebServerHandler::handle_page_settings(AsyncWebServerRequest *request)
 
 	content.replace("{{switchWIFI_checked}}", configHandler.getConfigSwitch("switchWIFI") ? "checked" : "");
 	content.replace("{{switchEPD_checked}}", configHandler.getConfigSwitch("switchEPD") ? "checked" : "");
+	content.replace("{{switchEPDorientation_checked}}", configHandler.getConfigSwitch("switchEPDorientation") ? "checked" : "");
 	content.replace("{{switchLED_checked}}", configHandler.getConfigSwitch("switchLED") ? "checked" : "");
 
 	content.replace("{{LEDbrightness}}", String(configHandler.getConfigLED("LEDbrightness")));
@@ -357,6 +361,7 @@ void WebServerHandler::handle_submit_modulswitch(AsyncWebServerRequest *request)
 	if (request->hasParam("switchEPD"))
 	{
 		configHandler.setConfigSwitch("switchEPD", atoi(request->getParam("switchEPD")->value().c_str()));
+		configHandler.setConfigSwitch("switchEPDorientation", request->hasParam("switchEPDorientation") ? 1 : 0);
 	}
 	if (request->hasParam("switchLED"))
 	{

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -189,6 +189,10 @@ void loop()
     {
         EPDHandler::getInstance().updateEPD(mhz19Readout, bme_data, localTime("%Y.%m.%d"), localTime("%H:%M"), currentSeconds);
     }
+    else
+    {
+        EPDHandler::getInstance().clearDisplay();
+    }
 	
 	if (configHandler.getConfigSwitch("switchLED"))
 	{

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -186,10 +186,10 @@ void loop()
 	webServer.setInputDataforBody(mhz19Readout, bme_data, localTime("%Y.%m.%d %H:%M:%S"));
 
 	if (configHandler.getConfigSwitch("switchEPD"))
-	{
-		EPDHandler::updateEPDvertical(mhz19Readout, bme_data, localTime("%Y.%m.%d"), localTime("%H:%M"), currentSeconds);
-	}
-
+    {
+        EPDHandler::getInstance().updateEPD(mhz19Readout, bme_data, localTime("%Y.%m.%d"), localTime("%H:%M"), currentSeconds);
+    }
+	
 	if (configHandler.getConfigSwitch("switchLED"))
 	{
 		LEDHandler &ledHandler = LEDHandler::getInstance();


### PR DESCRIPTION
Summary
Complete refactor of the EPD display handler with unified layout system, orientation control, stability fixes and web interface improvements.

Bug Fixes
fix: correct display/hibernate/end order in printHorizontally()
fix: add missing display.end() in printHorizontally()
fix: buffer size increased from 5 to 8 bytes to prevent float truncation
fix: float format changed from %f to %.1f to avoid unnecessary decimal places
fix: remove unimplemented printSensorValues() declaration from EPDHandler.h
fix: restore switchEPD on/off toggle in settings.htm
fix: fix nested form-row structure in settings.htm
fix: forceRefresh() now triggers immediate update regardless of elapsed time
fix: fetch BME680 data after updateSensorData() to ensure latest values are used
fix: add IAQ unit icon after IAQ value in printLayout()
fix: correct CO2 and IAQ placement in 2x2 horizontal grid layout
Features
feat: add EPD orientation dropdown with 4 options (vertical/horizontal × 90°/270°)
feat: add force refresh button to update EPD display on demand from settings page
feat: add clearDisplay() to show only turtle icon when EPD is disabled
feat: add /api/epd/refresh endpoint for manual display refresh
feat: add switchEPDorientation config entry persisted to NVS as int
Refactor
refactor: unify printVertically() and printHorizontally() into single printLayout()
refactor: introduce EPDLayout struct to control all coordinates via config
refactor: add verticalLayout(rotation) and horizontalLayout(rotation) factory functions
refactor: add rowTop2/rowBot2 to EPDLayout for correct 4-row vertical layout
refactor: merge getAlertColorInt() into getAlertColor() removing duplicate function
refactor: convert EPDHandler static methods to instance methods
refactor: switchEPDorientation stored as int instead of bool to support 4 values
refactor: redesign horizontal layout to 2x2 sensor grid with full-width footer
Notes
EPD orientation values: 0=vertical 90°, 1=vertical 270°, 2=horizontal 90°, 3=horizontal 270°
LittleFS filesystem image must be re-uploaded after this PR (settings.htm changed)
ESP32 restart required after changing EPD orientation or on/off state
clearDisplay() shows only the turtle icon in the corner when EPD is switched off
forceRefresh() uses ULONG_MAX trick to guarantee immediate update on next loop
EPDLayout coordinates may need fine-tuning depending on physical display mounting