### PR TITLE
2611 i2 c fix

### DIFF
--- a/src/BME680Handler.cpp
+++ b/src/BME680Handler.cpp
@@ -134,13 +134,18 @@ bool BME680Handler::updateSensorData(const unsigned long currentSeconds)
         _bme68xError = bmeSensor.bme68xStatus;
         Serial.println("[BME680] Runtime error: " + String(_bme68xError) +
                        " (" + String(_consecutiveErrors) + " consecutive)");
+        checkSensorStatus();
         if (_consecutiveErrors >= 5)
         {
             _sensorOk = false;
             Serial.println("[BME680] Too many errors, triggering recovery.");
         }
     }
-    checkSensorStatus();
+    else
+    {
+        _bme68xError = 0;
+        _consecutiveErrors = 0; // Reset on healthy status
+    }
     return false;
 }
 

--- a/src/BME680Handler.cpp
+++ b/src/BME680Handler.cpp
@@ -34,27 +34,8 @@ BME680Handler::BME680Handler()
 	delay(500);
 	pinMode(LED_BUILTIN, OUTPUT);
 
-	// IMPORTANT Retry mechanism
-	uint8_t retries = 0;
-    // Try address 0x76 first, then 0x77. On the board SDO is not connected and i do not want to solder to GND. So the adress could be 0x77 or 0x76
-	uint8_t addresses[2] = {BME68X_I2C_ADDR_LOW, BME68X_I2C_ADDR_HIGH};
-    do {
-        uint8_t addr = addresses[retries % 2];
-        Serial.println("[BME680] Trying address 0x" + String(addr, HEX) +
-                       ", attempt " + String(retries + 1) + "/4");
-        bmeSensor.begin(addr, Wire);
-        if (bmeSensor.bme68xStatus == BME68X_OK)
-        {
-            Serial.println("[BME680] Found at address 0x" + String(addr, HEX));
-            break;
-        }
-        Wire.end();
-        delay(500);
-        Wire.begin(PIN_BME680_SDA, PIN_BME680_SCL);
-        Wire.setClock(100000);
-        delay(500);
-        retries++;
-    } while (retries < 4);
+	Serial.println("[BME680] Initializing at fixed address 0x77 (CS hardwired HIGH)");
+    bmeSensor.begin(BME68X_I2C_ADDR_HIGH, Wire);
 
 	if (bmeSensor.bme68xStatus == BME68X_OK) {
         _sensorOk = true;

--- a/src/BME680Handler.cpp
+++ b/src/BME680Handler.cpp
@@ -91,12 +91,8 @@ bool BME680Handler::updateSensorData(const unsigned long currentSeconds)
             Wire.setClock(100000);
             delay(500);
             
-            uint8_t recoveryAddresses[2] = {BME68X_I2C_ADDR_LOW, BME68X_I2C_ADDR_HIGH};
-            for (uint8_t i = 0; i < 2; i++)
-            {
-                bmeSensor.begin(recoveryAddresses[i], Wire);
-                if (bmeSensor.bme68xStatus == BME68X_OK) break;
-            }
+            bmeSensor.begin(BME68X_I2C_ADDR_HIGH, Wire);
+            delay(200);
 
             if (bmeSensor.bme68xStatus == BME68X_OK)
             {

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -22,7 +22,7 @@
 #define SEALEVELPRESSURE_HPA 1015
 #define TEMPERATUR_OFFSET -3.5
 
-#define DeviceName "Turtle 28.02.2026"
+#define DeviceName "Turtle 07.03.2026"
 #define TIMEZONE "CET-1CEST,M3.5.0,M10.5.0/3"
 
 #define PIN_BME680_SDA 21

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,11 +29,11 @@
 // Bosch BME680
 // ---------------
 // GND -> GND
-// VCC -> 5V
+// VCC -> 3,3-5V
 // SCL -> 22
 // SDA -> 21
 // SD0 -> -
-// CS  -> -
+// CS  -> 3,3V
 
 // OOP
 #include "BME680Handler.h"


### PR DESCRIPTION
fix(BME680): resolve I2C communication failure (COM_FAIL -2)

Root cause: CS pin was floating on the BME680 breakout board, causing
the sensor to randomly start in SPI mode instead of I2C mode on power-up.

Hardware fix:
- CS pin hardwired to 3.3V to permanently force I2C mode

Code changes:
- Replace address scan loop with fixed I2C address 0x77 (SDO floating)
- Simplify runtime recovery to use fixed address 0x77
- Call checkSensorStatus() only on actual errors, not every BSEC cycle
- Reset consecutive error counter when sensor status returns to healthy
- Fix outdated log message "after 3 retries" after init failure