### PR TITLE
2610 wlan adjustment

### DIFF
--- a/src/Credentials_example.h
+++ b/src/Credentials_example.h
@@ -7,6 +7,9 @@
 #define WIFI_SSID "";
 #define WIFI_PW "";
 
+#define AP_SSID "";
+#define AP_PASSWORD "";
+
 #define MQTT_USER "";
 #define MQTT_PASS "";
 

--- a/src/WebServerHandler.cpp
+++ b/src/WebServerHandler.cpp
@@ -280,11 +280,12 @@ void WebServerHandler::handle_submit_WLANcredentials(AsyncWebServerRequest *requ
 		return;
 	}
 	request->send(200, "text/html",
-    "<html><head>"
-    "<meta http-equiv='refresh' content='6;url=/'>"
-    "</head><body style='font-family:sans-serif;padding:40px'>"
-    "<h2>WLAN Einstellungen gespeichert.</h2>"
-    "<p>Weiterleitung in 6 Sekunden.</p>"
+    "<html><head></head>"
+    "<body style='font-family:sans-serif;padding:40px'>"
+    "<h2>WLAN credentials saved.</h2>"
+    "<p>The ESP32 is restarting and connecting to your network.</p>"
+    "<p>Please connect your device to the same WiFi network and navigate to "
+    "<strong>http://" + configHandler.getConfigDevice("deviceName") + ".local</strong></p>"
     "</body></html>");
 
 	xTaskCreate([](void*) {

--- a/src/WiFiHandler.cpp
+++ b/src/WiFiHandler.cpp
@@ -19,8 +19,8 @@ void WiFiHandler::loadWiFiCredentials()
 
 void WiFiHandler::setupAPMode()
 {
-	const char *apSSID = "sensorturle 192.168.4.1";
-	const char *apPassword = "sensorturtle";
+	const char *apSSID = AP_SSID;
+    const char *apPassword = AP_PASSWORD;
 
 	WiFi.softAP(apSSID, apPassword);
 	Serial.println("[AP MODE] no known wifi credentials found, starting AP mode");

--- a/src/WiFiHandler.cpp
+++ b/src/WiFiHandler.cpp
@@ -69,43 +69,24 @@ static void setupMDNS()
 
 void WiFiHandler::initWifi()
 {
-	int wifiWaitCount = 0;
-	// set device for mDNS and hostname
-	String hostname = configHandler.getConfigDevice("deviceName");
-	hostname.replace(" ", "-");
-	hostname.toLowerCase();
-	WiFi.setHostname(hostname.c_str());
-	WiFi.setAutoReconnect(true);
-	WiFi.persistent(true);
-#ifdef DEBUG
-	Serial.print("\n[WIFI] Connecting to ");
-	Serial.println(WIFI_SSID);
-#endif
-	loadWiFiCredentials();
-	WiFi.begin(_ssid.c_str(), _password.c_str());
+    String hostname = configHandler.getConfigDevice("deviceName");
+    hostname.replace(" ", "-");
+    hostname.toLowerCase();
+    WiFi.setHostname(hostname.c_str());
+    WiFi.setAutoReconnect(true);
+    WiFi.persistent(true);
 
-	while (WiFiClass::status() != WL_CONNECTED && wifiWaitCount < 20)
-	{
-		delay(250);
-		wifiWaitCount++;
-	}
-	if (WiFiClass::status() == WL_CONNECTED)
-	{
-		Serial.print("[WIFI] connected. IP address: ");
-		Serial.println(WiFi.localIP());
-		String mdnsName = configHandler.getConfigDevice("deviceName");
-		mdnsName.replace(" ", "-");
-		if (mdns_init() == ESP_OK)
-		{
-			mdns_hostname_set(mdnsName.c_str());
-			Serial.println("[WIFI] mDNS gestartet: http://" + mdnsName + ".local");
-		}
-	}
-	else
-	{
-		Serial.println("[WIFI] Starting AP mode. Please connect to the esp32 wlan");
-		setupAPMode();
-	}
+    loadWiFiCredentials();
+
+    if (connectToWifi())
+    {
+        setupMDNS();
+    }
+    else
+    {
+        Serial.println("[WIFI] No connection, starting AP mode");
+        setupAPMode();
+    }
 }
 
 void WiFiHandler::ReStart()

--- a/src/WiFiHandler.cpp
+++ b/src/WiFiHandler.cpp
@@ -91,29 +91,10 @@ void WiFiHandler::initWifi()
 
 void WiFiHandler::ReStart()
 {
-#ifdef DEBUG
-	Serial.println();
-	Serial.print("[WIFI] Connecting to: ");
-	Serial.println(WIFI_SSID);
-#endif
-	loadWiFiCredentials();
-	WiFi.disconnect(true);
-	delay(100);
-	WiFi.begin(_ssid.c_str(), _password.c_str());
-	int wifiWaitCount = 0;
-	while (WiFiClass::status() != WL_CONNECTED && wifiWaitCount < 20)
-	{
-		delay(250);
-		wifiWaitCount++;
-	}
-#ifdef DEBUG
-	if (WiFiClass::status() == WL_CONNECTED)
-	{
-		Serial.println();
-		Serial.print("[WIFI] still connected. IP: ");
-		Serial.println(WiFi.localIP());
-	}
-#endif
+    loadWiFiCredentials();
+    WiFi.disconnect(true);
+    delay(100);
+    connectToWifi();
 }
 
 bool WiFiHandler::StatusCheck()

--- a/src/WiFiHandler.cpp
+++ b/src/WiFiHandler.cpp
@@ -7,13 +7,13 @@
 #include "ConfigHandler.h"
 extern ConfigHandler &configHandler;
 unsigned long WiFiHandler::_lastRunSeconds = 0;
-String password;
-String ssid;
+static String _ssid;
+static String _password;
 
 void WiFiHandler::loadWiFiCredentials()
 {
-	ssid = configHandler.getConfigDevice("wlanSSID");
-	password = configHandler.getConfigDevice("wlanPASSWORD");
+    _ssid     = configHandler.getConfigDevice("wlanSSID");
+    _password = configHandler.getConfigDevice("wlanPASSWORD");
 	Serial.println("[WIFI] get credentails");
 }
 
@@ -43,7 +43,7 @@ void WiFiHandler::initWifi()
 	Serial.println(WIFI_SSID);
 #endif
 	loadWiFiCredentials();
-	WiFi.begin(ssid.c_str(), password.c_str());
+	WiFi.begin(_ssid.c_str(), _password.c_str());
 
 	while (WiFiClass::status() != WL_CONNECTED && wifiWaitCount < 20)
 	{
@@ -79,7 +79,7 @@ void WiFiHandler::ReStart()
 	loadWiFiCredentials();
 	WiFi.disconnect(true);
 	delay(100);
-	WiFi.begin(ssid.c_str(), password.c_str());
+	WiFi.begin(_ssid.c_str(), _password.c_str());
 	int wifiWaitCount = 0;
 	while (WiFiClass::status() != WL_CONNECTED && wifiWaitCount < 20)
 	{

--- a/src/WiFiHandler.cpp
+++ b/src/WiFiHandler.cpp
@@ -54,6 +54,19 @@ void WiFiHandler::setupAPMode()
 	Serial.println(WiFi.softAPIP());
 }
 
+static void setupMDNS()
+{
+    String name = configHandler.getConfigDevice("deviceName");
+    name.replace(" ", "-");
+    name.toLowerCase();
+
+    if (mdns_init() == ESP_OK)
+    {
+        mdns_hostname_set(name.c_str());
+        Serial.println("[WIFI] mDNS started: http://" + name + ".local");
+    }
+}
+
 void WiFiHandler::initWifi()
 {
 	int wifiWaitCount = 0;

--- a/src/WiFiHandler.cpp
+++ b/src/WiFiHandler.cpp
@@ -17,6 +17,32 @@ void WiFiHandler::loadWiFiCredentials()
 	Serial.println("[WIFI] get credentails");
 }
 
+static bool connectToWifi()
+{
+    if (_ssid.isEmpty())
+    {
+        Serial.println("[WIFI] No SSID configured, skipping connection attempt");
+        return false;
+    }
+
+    WiFi.begin(_ssid.c_str(), _password.c_str());
+
+    int attempts = 0;
+    while (WiFiClass::status() != WL_CONNECTED && attempts < 20)
+    {
+        delay(250);
+        attempts++;
+    }
+
+    bool connected = (WiFiClass::status() == WL_CONNECTED);
+    if (connected)
+        Serial.println("[WIFI] Connected. IP: " + WiFi.localIP().toString());
+    else
+        Serial.println("[WIFI] Connection failed after " + String(attempts) + " attempts");
+
+    return connected;
+}
+
 void WiFiHandler::setupAPMode()
 {
 	const char *apSSID = AP_SSID;
@@ -98,13 +124,14 @@ void WiFiHandler::ReStart()
 
 bool WiFiHandler::StatusCheck()
 {
-	wl_status_t status = WiFiClass::status();
-	if (status != WL_CONNECTED)
-	{
-		ReStart();
-		Serial.println("[WIFI] restarting WiFi connection");
-	}
-	return status == WL_CONNECTED;
+    bool connected = (WiFiClass::status() == WL_CONNECTED);
+    if (!connected)
+    {
+        Serial.println("[WIFI] Connection lost, reconnecting...");
+        ReStart();
+        connected = (WiFiClass::status() == WL_CONNECTED);
+    }
+    return connected;
 }
 
 bool WiFiHandler::checkWifiStatus(unsigned long currentSeconds)


### PR DESCRIPTION
Features & Improvements
Configurable Access Point Credentials
The SSID and password for the fallback Access Point (AP mode) are no longer hardcoded. They are now defined via AP_SSID and AP_PASSWORD in Credentials_example.h, allowing customisation without any code changes.
Improved User Guidance After WLAN Configuration
The confirmation page shown after saving WLAN credentials has been reworked: instead of an automatic redirect after 6 seconds, the user is now clearly informed that the ESP32 is restarting and connecting to the network. The mDNS link (http://<deviceName>.local) is displayed directly, so the device can be reached immediately after connecting — no more confusion or manual IP address hunting.
WiFiHandler Refactoring for Better Maintainability
The WiFi connection logic has been split into dedicated, reusable functions:

connectToWifi() — encapsulates the entire connection process including timeout handling and logging
setupMDNS() — isolates the mDNS configuration

This eliminates duplicated code (the nearly identical connection flow previously existed in two places) and makes the ReStart() function significantly leaner.
More Robust Reconnect Behaviour
The checkWifiConnection() function now re-checks the connection status after a failed reconnect attempt before returning false, making behaviour during connection drops more reliable.
SSID Guard: No Connection Attempt Without a Configured Network
If no SSID is set, a connection attempt is now aborted early and logged, rather than running into a dead end.