### PR TITLE
2611 edp bus ypin

### DIFF
--- a/doc/PROJECT_SUMMARY.md
+++ b/doc/PROJECT_SUMMARY.md
@@ -1,10 +1,10 @@
 # Project Summary: CO2 Turtle
 
 ## Overview
-A C++ firmware for an ESP32 FireBeetle32 that measures indoor air quality
-(CO2, temperature, humidity, IAQ) and displays the data on an E-Ink display
-and a WS2812B LED strip. Configuration is done via a web interface.
-The project is built with PlatformIO (Arduino framework).
+C++ firmware for a DFRobot FireBeetle32 (ESP32) that measures indoor air quality
+(CO2, temperature, humidity, IAQ) and displays the data on a 3-color E-Ink display
+and a WS2812B LED strip. All settings are configurable at runtime via a web interface
+without recompiling. Built with PlatformIO (Arduino framework).
 
 ---
 
@@ -15,12 +15,15 @@ The project is built with PlatformIO (Arduino framework).
 | MCU | DFRobot FireBeetle32 (ESP32 WROOM-32D) |
 | BME680 | Temperature, humidity, pressure, IAQ via I2C (SDA: GPIO21, SCL: GPIO22) |
 | MH-Z19B | CO2 sensor via HardwareSerial2 (RX: GPIO17, TX: GPIO16) |
-| E-Ink display | GxEPD2 213 Z98c (122x250px, 3-color) via SPI (DC: GPIO27, CS: GPIO5, CLK: GPIO18, DIN: GPIO23) |
+| E-Ink display | GxEPD2 213 Z98c (122×250px, 3-color B/W/R) via SPI (DC: GPIO27, CS: GPIO5, CLK: GPIO18, DIN: GPIO23, RST: GPIO26, BUSY: GPIO25) |
 | LED strip | WS2812B, 38 LEDs on GPIO4, powered by 5V |
-| Power | 5V external PSU; ESP and sensors (except MH-Z19B) run on 3.3V from ESP onboard regulator |
+| Power | 5V external PSU; ESP and sensors (except MH-Z19B) run on 3.3V from onboard regulator |
 
-**BME680 wiring note:** CS pin is hardwired to 3.3V (forces I2C mode).
-SDO is floating → fixed I2C address 0x77.
+**BME680 wiring note:** CS pin hardwired to 3.3V (forces I2C mode). SDO floating → fixed I2C address 0x77.
+
+**E-Ink pin note:** RST and BUSY pins are wired. `EPD_PIN_RST` and `EPD_PIN_BUSY` in `Configuration.h`
+can be set to `-1` as a compile-time fallback if the pins are not connected – in that case rendering
+falls back to FreeRTOS tasks to avoid blocking the async TCP stack.
 
 ---
 
@@ -28,10 +31,10 @@ SDO is floating → fixed I2C address 0x77.
 
 | Library | Purpose |
 |---|---|
-| BSEC v1.8 (Bosch) | BME680 IAQ processing, runs at LP mode (3s sample rate) |
+| BSEC v1.8 (Bosch) | BME680 IAQ processing, LP mode (3s sample rate) |
 | GxEPD2 | E-Ink display driver |
-| ESPAsyncWebServer | Async web interface for configuration |
-| AsyncMqttClient | Optional MQTT publishing (Home Assistant discovery supported) |
+| ESPAsyncWebServer | Async web interface |
+| AsyncMqttClient | MQTT publishing (optional, Home Assistant discovery) |
 | FastLED | WS2812B LED strip control |
 | MH-Z19 (wifwaf) | CO2 sensor library |
 | LittleFS | Filesystem for web interface static files |
@@ -44,54 +47,88 @@ SDO is floating → fixed I2C address 0x77.
 
 ```
 src/
-├── main.cpp                – Setup and main loop
-├── Configuration.h         – Compile-time pin definitions and defaults
-├── Credentials.h           – WiFi/MQTT credentials (not in repo, see Credentials_example.h)
-├── BME680Handler.cpp/.h    – BSEC sensor reading, EEPROM state persistence
-├── MHZ19Handler.cpp/.h     – CO2 sensor reading with error recovery
-├── EPDHandler.cpp/.h       – E-Ink display rendering (vertical/horizontal layout)
-├── LEDHandler.cpp/.h       – LED strip status display
-├── LEDsection.h            – LED section definitions (enum + start/end indices)
-├── WiFiHandler.cpp/.h      – WiFi init, reconnect, AP fallback mode
-├── WebServerHandler.cpp/.h – Async web server, all HTTP handlers
-├── MqttClientHandler.cpp/.h– MQTT publishing and Home Assistant discovery
-├── ConfigHandler.cpp/.h    – Runtime config via NVS (Preferences)
-└── DataCO2.cpp/.h          – Value object for MH-Z19B readings
-data/static/                – Web interface HTML/CSS files (served from LittleFS)
+├── main.cpp                  – Setup and main loop
+├── Configuration.h           – Compile-time pin definitions, defaults, EPD pin config
+├── Credentials.h             – WiFi/MQTT credentials (not in repo, see Credentials_example.h)
+├── BME680Handler.cpp/.h      – BSEC sensor reading, EEPROM state persistence
+├── MHZ19Handler.cpp/.h       – CO2 sensor reading with error recovery
+├── EPDHandler.cpp/.h         – E-Ink rendering, 4 orientations, FreeRTOS task fallback
+├── LEDHandler.cpp/.h         – LED strip status display
+├── LEDsection.h              – LED section definitions (enum + start/end indices)
+├── WiFiHandler.cpp/.h        – WiFi init, reconnect, AP fallback mode
+├── WebServerHandler.cpp/.h   – Async web server, all HTTP handlers
+├── MqttClientHandler.cpp/.h  – MQTT publishing and Home Assistant discovery
+├── ConfigHandler.cpp/.h      – Runtime config via NVS (Preferences)
+├── DataCO2.cpp/.h            – Value object for MH-Z19B readings
+├── GxEPD2_display_selection_new_style.h – Display class/driver selection, pin wiring
+└── symbol.h                  – 18×18px and 24×24px bitmap icons (PROGMEM)
+data/static/                  – Web interface HTML/CSS (served from LittleFS)
+  ├── index.htm / template.htm
+  ├── settings.htm            – Module switches, intervals, sensor config
+  ├── mqtt.htm                – MQTT connection settings
+  ├── wlan.htm                – WiFi credentials
+  └── style.css
 ```
 
 ---
 
 ## Architecture
 
-All handlers are **Singletons** with `getInstance()`. Each handler manages
-its own update interval internally via `updateSensorData(currentSeconds)` or
-similar methods. The main loop calls all handlers every cycle and passes
-`millis()/1000` as `currentSeconds`.
+All handlers are **Singletons** accessed via `getInstance()`. Each handler manages
+its own update interval internally. The main loop calls all handlers every cycle,
+passing `millis()/1000` as `currentSeconds`.
 
-Data flows like this:
 ```
 BME680Handler → Bsec object    ─┐
-MHZ19Handler  → DataCO2 object ─┼→ EPDHandler, LEDHandler, WebServerHandler, MqttClientHandler
+MHZ19Handler  → DataCO2 object ─┼→ EPDHandler · LEDHandler · WebServerHandler · MqttClientHandler
+                                 └→ ConfigHandler (shared by all handlers)
 ```
 
 ---
 
 ## Configuration System
 
-Runtime configuration is stored in NVS via the `ConfigHandler` singleton.
-On first boot, defaults from `Configuration.h` are written to NVS.
-The web interface allows changing all settings at runtime without recompiling.
+Runtime configuration is stored in NVS via `ConfigHandler`. On first boot, defaults
+from `Configuration.h` are written to NVS. All settings are changeable via the web
+interface without recompiling.
 
 Config is split into 5 maps:
 
 | Map | Keys |
 |---|---|
-| Switch | switchWIFI, switchEPD, switchEPDorientation, switchLED, switchMQTT |
+| Switch | switchWIFI, switchEPD, switchEPDorientation (Int 0–3), switchLED, switchMQTT |
 | Interval (seconds) | intervalMHZ19, intervalBME680, intervalWiFi, intervalEPD, intervalLED, intervalMQTT, intervalPRINT |
 | Device | deviceName, timezone, wlanSSID, wlanPASSWORD, mqttHOST, mqttPORT, mqttUSER, mqttPASSWORD, mqttUSERen |
 | LED | LEDbrightness (range 2–255) |
 | Sensor | pressure (hPa), tempOffset (stored as int × 10) |
+
+---
+
+## E-Ink Display
+
+The display supports 4 orientations selectable via `switchEPDorientation`:
+
+| Value | Orientation | GxEPD2 rotation |
+|---|---|---|
+| 0 | Vertical 90° (cable up) | 2 |
+| 1 | Vertical 270° (cable down) | 0 |
+| 2 | Horizontal 90° (cable left) | 1 |
+| 3 | Horizontal 270° (cable right) | 3 |
+
+**Layout:** Two sensor columns (Temp/Hum left, CO2/IAQ right) with a footer showing
+WiFi icon + SSID, IP address, date/time, and device name with turtle icon.
+Alert coloring (red/black) applies per sensor value against configurable thresholds.
+
+**Rendering:** With BUSY pin wired (`EPD_PIN_BUSY >= 0`), `printLayout()` and
+`wipeDisplay()` are called directly – GxEPD2 uses the real BUSY signal (~500ms wait).
+Without BUSY pin, both operations run in dedicated one-shot FreeRTOS tasks (4096 byte
+stack each) to prevent blocking the async TCP stack during the ~2–3s busy-wait delay.
+
+**Standby:** When the EPD is disabled, a sleeping turtle is shown
+before the display hibernates.
+
+**WiFi fallback:** If no WiFi connection is available, the footer shows
+`"no WLAN"` / `"---"` / `"--:--"` instead of empty or `0.0.0.0` values.
 
 ---
 
@@ -106,67 +143,53 @@ Config is split into 5 maps:
 
 ---
 
-## BME680 Handler Details
+## BME680 Handler
 
 - BSEC config: `generic_33v_3s_4d` (3.3V, 3s sample rate, 4 days burn-in)
-- BSEC IAQ calibration state is persisted to EEPROM:
+- IAQ calibration persisted to EEPROM:
   - First save: when IAQ accuracy reaches 3
   - Periodic saves: every 360 minutes
-  - On startup: state is restored from EEPROM if valid
-- Onboard LED (LED_BUILTIN) lights up briefly during EEPROM state writes
-- Runtime recovery: if 5 consecutive errors occur, the handler resets
-  the I2C bus and reinitializes the sensor, retrying every 60 seconds
+  - On startup: state restored from EEPROM if valid
+- Onboard LED (LED_BUILTIN) lights briefly during EEPROM writes
+- Recovery: after 5 consecutive errors, I2C bus reset + sensor reinitialization, retrying every 60s
 
 ---
 
-## MH-Z19B Handler Details
+## MH-Z19B Handler
 
-- Uses HardwareSerial2 at 9600 baud
+- HardwareSerial2 at 9600 baud
 - Auto-calibration enabled
-- Error recovery: after 3 consecutive errors, Serial2 is restarted
-- `DataCO2` stores: regular CO2, raw CO2, limited CO2, background CO2,
-  temp adjustment, temperature, accuracy
-
----
-
-## E-Ink Display
-
-- Supports two layouts selectable via `switchEPDorientation`:
-  vertical (90°/270°) and horizontal (90°/270°)
-- Shows: CO2 (ppm), temperature (°C), humidity (%), IAQ, date, time, device name
-- Color thresholds are used for alert coloring (red/black highlights)
-- Forced full refresh at configurable interval (`intervalEPD`, default 900s)
+- Recovery: after 3 consecutive errors, Serial2 is restarted
+- `DataCO2` stores: regular CO2, raw CO2, limited CO2, background CO2, temp adjustment, temperature, accuracy
 
 ---
 
 ## MQTT (optional, disabled by default)
 
-- Home Assistant MQTT discovery support via `publishDiscovery()`
+- Home Assistant MQTT discovery via `publishDiscovery()` on connect
 - Publishes all sensor values at `intervalMQTT`
-- Optional user/password authentication
-- Enable via `switchMQTT` in web interface or `Configuration.h`
+- Optional user/password authentication (`mqttUSERen`)
+- Host, port, credentials fully configurable via web UI without recompiling
 
 ---
 
 ## Important Notes
 
-- `Credentials.h` is not in the repository. Copy `Credentials_example.h`
-  and fill in WiFi and MQTT credentials before building.
-- If WiFi credentials are missing, the device falls back to AP mode.
-- `DEBUG` mode (set in `Configuration.h`) enables verbose Serial output
-  and RAM usage reporting.
+- `Credentials.h` is **not in the repository**. Copy `Credentials_example.h` and fill in
+  WiFi/MQTT credentials before building.
+- If WiFi credentials are missing or connection fails, the device falls back to AP mode.
+- `DEBUG 1` in `Configuration.h` enables verbose Serial output and RAM usage reporting.
 - The MH-Z19B is powered by 5V directly from the PSU, not from the ESP.
+- `switchEPDorientation` is stored as **Int** (not Bool) to support values 0–3.
 
 ---
 
 ## How I Want Code Changes Delivered
 
-Please structure every code change so that it fits into a single Git commit
-and can be applied manually. This means:
+Structure every code change so it fits into a single Git commit and can be applied manually:
 
-1. **The exact code change** – show clearly what to remove (ALT) and what
-   to replace it with (NEU), including enough surrounding context to locate
-   the change unambiguously in the file. Always include the filename.
+1. **The exact code change** – show what to remove (ALT) and replace it with (NEU),
+   including enough surrounding context to locate the change unambiguously. Always include the filename.
 
 2. **A commit message** in the format:
    ```
@@ -176,5 +199,8 @@ and can be applied manually. This means:
    ```
    Common types: `feat`, `fix`, `refactor`, `docs`, `chore`
 
-If a larger change logically consists of multiple independent commits,
-split it into separate blocks – one (ALT/NEU + commit message) per commit.
+If a larger change consists of multiple independent commits, split into separate
+ALT/NEU + commit message blocks – one per commit.
+
+- The user decides which changes to apply. Do not assume a suggested
+  change was implemented unless the user explicitly confirms it.

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -47,4 +47,10 @@
 
 extern const char* DeviceNameConf;
 
-#endif //CO2_TURTLE_CONFIGURATION_H
+// EPD hardware pins – set to -1 if not wired
+#define EPD_PIN_RST  26
+#define EPD_PIN_BUSY 25
+#define EPD_PIN_DC 27
+#define EPD_PIN_CS 5
+
+#endif 

--- a/src/EPDHandler.cpp
+++ b/src/EPDHandler.cpp
@@ -188,12 +188,20 @@ void EPDHandler::updateEPD(const DataCO2 &co2, const Bsec &bme_data, const Strin
         (orientation == 3) ? layout_horizontal(3) :
                              layout_vertical(2);
 
-    if (_taskRunning) return;  // previous render still in progress
-    _taskRunning = true;
-
-    EPDTaskParams *params = new EPDTaskParams{this, co2, bme_data, date, time, ssid, ip, bmeOk, layout};
-    xTaskCreate(EPDHandler::epdRenderTask, "epd_render", 4096, params, 1, nullptr);
-}
+    #if EPD_PIN_BUSY >= 0
+        // BUSY pin wired: display.display() uses real busy signal, short wait
+        if (_taskRunning) return;
+        _taskRunning = true;
+        printLayout(co2, bme_data, date, time, ssid, ip, bmeOk, layout);
+        _taskRunning = false;
+    #else
+        // BUSY pin not wired: blocking delay ~2-3s, must run in FreeRTOS task
+        if (_taskRunning) return;
+        _taskRunning = true;
+        EPDTaskParams *params = new EPDTaskParams{this, co2, bme_data, date, time, ssid, ip, bmeOk, layout};
+        xTaskCreate(EPDHandler::epdRenderTask, "epd_render", 4096, params, 1, nullptr);
+    #endif
+    }
 
 void EPDHandler::wipeDisplay()
 {
@@ -202,12 +210,27 @@ void EPDHandler::wipeDisplay()
     _taskRunning = true;
 
     int ori = configHandler.getConfigSwitch("switchEPDorientation");
-    EPDWipeParams *wp = new EPDWipeParams{this,
+    EPDLayout l =
         (ori == 1) ? layout_vertical(0)   :
         (ori == 2) ? layout_horizontal(1) :
         (ori == 3) ? layout_horizontal(3) :
-                     layout_vertical(2)};
-    xTaskCreate(epdWipeTask, "epd_wipe", 4096, wp, 1, nullptr);
+                     layout_vertical(2);
+
+    #if EPD_PIN_BUSY >= 0
+        display.init(BAUDRATE);
+        display.fillScreen(GxEPD_WHITE);
+        display.setFullWindow();
+        display.setRotation(l.rotation);
+        display.drawInvertedBitmap(l.footerTurtleX,   l.footerTurtleY,   bitmap_turtlesleep, 18, 18, GxEPD_RED);
+        display.drawInvertedBitmap(l.footerWlanIconX, l.footerWlanIconY, bitmap_wlan,        18, 18, GxEPD_BLACK);
+        display.display(false);
+        display.hibernate();
+        display.end();
+        _taskRunning = false;
+    #else
+        EPDWipeParams *wp = new EPDWipeParams{this, l};
+        xTaskCreate(epdWipeTask, "epd_wipe", 4096, wp, 1, nullptr);
+    #endif
 }
 
 void EPDHandler::epdWipeTask(void *pvParameters)

--- a/src/GxEPD2_display_selection_new_style.h
+++ b/src/GxEPD2_display_selection_new_style.h
@@ -1,3 +1,4 @@
+#include "Configuration.h"
 // Display Library example for SPI e-paper panels from Dalian Good Display and boards from Waveshare.
 // Requires HW SPI and Adafruit_GFX. Caution: the e-paper panels require 3.3V supply AND data lines!
 //
@@ -71,7 +72,8 @@
 #else
 
 
-GxEPD2_DISPLAY_CLASS<GxEPD2_DRIVER_CLASS, MAX_HEIGHT(GxEPD2_DRIVER_CLASS)> display(GxEPD2_DRIVER_CLASS(/*CS=5*/ 5, /*DC=TX2*/ 27, /*RST=*/ -1, /*BUSY=*/ -1)); // my suggested wiring and proto board
+GxEPD2_DISPLAY_CLASS<GxEPD2_DRIVER_CLASS, MAX_HEIGHT(GxEPD2_DRIVER_CLASS)> display(GxEPD2_DRIVER_CLASS(/*CS=*/ EPD_PIN_CS, /*DC=*/ EPD_PIN_DC, /*RST=*/ EPD_PIN_RST, /*BUSY=*/ EPD_PIN_BUSY));
+
 
 #endif
 #else // GxEPD2_1248 or GxEPD2_1248c

--- a/src/GxEPD2_display_selection_new_style.h
+++ b/src/GxEPD2_display_selection_new_style.h
@@ -1,4 +1,3 @@
-#include "Configuration.h"
 // Display Library example for SPI e-paper panels from Dalian Good Display and boards from Waveshare.
 // Requires HW SPI and Adafruit_GFX. Caution: the e-paper panels require 3.3V supply AND data lines!
 //
@@ -17,48 +16,30 @@
 // NOTE: you may need to adapt or select for your wiring in the processor specific conditional compile sections below
 
 // select the display class (only one), matching the kind of display panel
-//#define GxEPD2_DISPLAY_CLASS GxEPD2_BW
+
+#include "Configuration.h"  // for EPD_PIN_RST, EPD_PIN_BUSY
+
 #define GxEPD2_DISPLAY_CLASS GxEPD2_3C
-//#define GxEPD2_DISPLAY_CLASS GxEPD2_7C
+#define GxEPD2_DRIVER_CLASS  GxEPD2_213_Z98c // GDEY0213Z98 122x250, SSD1680
 
-
-// 3-color e-papers
-//#define GxEPD2_DRIVER_CLASS GxEPD2_154c     // GDEW0154Z04 200x200, IL0376F, no longer available
-//#define GxEPD2_DRIVER_CLASS GxEPD2_154_Z90c // GDEH0154Z90 200x200, SSD1681
-//#define GxEPD2_DRIVER_CLASS GxEPD2_213c     // GDEW0213Z16 104x212, UC8151 (IL0373)
-//#define GxEPD2_DRIVER_CLASS GxEPD2_213_Z19c // GDEH0213Z19 104x212, UC8151D
-#define GxEPD2_DRIVER_CLASS GxEPD2_213_Z98c // GDEY0213Z98 122x250, SSD1680
-//#define GxEPD2_DRIVER_CLASS GxEPD2_290c     // GDEW029Z10  128x296, UC8151 (IL0373)
-//#define GxEPD2_DRIVER_CLASS GxEPD2_290_Z13c // GDEH029Z13  128x296, UC8151D
-//#define GxEPD2_DRIVER_CLASS GxEPD2_290_C90c // GDEM029C90  128x296, SSD1680
-
-
-
-// SS is usually used for CS. define here for easy change
 #ifndef EPD_CS
-
-#define EPD_CS SS
+#define EPD_CS SS  // GPIO5
 #endif
 
 #if defined(GxEPD2_DISPLAY_CLASS) && defined(GxEPD2_DRIVER_CLASS)
 
-// somehow there should be an easier way to do this
 #define GxEPD2_BW_IS_GxEPD2_BW true
 #define GxEPD2_3C_IS_GxEPD2_3C true
 #define GxEPD2_7C_IS_GxEPD2_7C true
-#define GxEPD2_1248_IS_GxEPD2_1248 true
-#define GxEPD2_1248c_IS_GxEPD2_1248c true
 #define IS_GxEPD(c, x) (c##x)
 #define IS_GxEPD2_BW(x) IS_GxEPD(GxEPD2_BW_IS_, x)
 #define IS_GxEPD2_3C(x) IS_GxEPD(GxEPD2_3C_IS_, x)
 #define IS_GxEPD2_7C(x) IS_GxEPD(GxEPD2_7C_IS_, x)
-#define IS_GxEPD2_1248(x) IS_GxEPD(GxEPD2_1248_IS_, x)
-#define IS_GxEPD2_1248c(x) IS_GxEPD(GxEPD2_1248c_IS_, x)
 
 #include "GxEPD2_selection_check.h"
 
 #if defined(ESP32)
-#define MAX_DISPLAY_BUFFER_SIZE 65536ul // e.g.
+#define MAX_DISPLAY_BUFFER_SIZE 65536ul
 #if IS_GxEPD2_BW(GxEPD2_DISPLAY_CLASS)
 #define MAX_HEIGHT(EPD) (EPD::HEIGHT <= MAX_DISPLAY_BUFFER_SIZE / (EPD::WIDTH / 8) ? EPD::HEIGHT : MAX_DISPLAY_BUFFER_SIZE / (EPD::WIDTH / 8))
 #elif IS_GxEPD2_3C(GxEPD2_DISPLAY_CLASS)
@@ -66,24 +47,9 @@
 #elif IS_GxEPD2_7C(GxEPD2_DISPLAY_CLASS)
 #define MAX_HEIGHT(EPD) (EPD::HEIGHT <= (MAX_DISPLAY_BUFFER_SIZE) / (EPD::WIDTH / 2) ? EPD::HEIGHT : (MAX_DISPLAY_BUFFER_SIZE) / (EPD::WIDTH / 2))
 #endif
-// adapt the constructor parameters to your wiring
-#if !IS_GxEPD2_1248(GxEPD2_DRIVER_CLASS) && !IS_GxEPD2_1248c(GxEPD2_DRIVER_CLASS)
-#if defined(ARDUINO_LOLIN_D32_PRO)
-#else
-
 
 GxEPD2_DISPLAY_CLASS<GxEPD2_DRIVER_CLASS, MAX_HEIGHT(GxEPD2_DRIVER_CLASS)> display(GxEPD2_DRIVER_CLASS(/*CS=*/ EPD_PIN_CS, /*DC=*/ EPD_PIN_DC, /*RST=*/ EPD_PIN_RST, /*BUSY=*/ EPD_PIN_BUSY));
 
-
-#endif
-#else // GxEPD2_1248 or GxEPD2_1248c
-// Waveshare 12.48 b/w or b/w/r SPI display board and frame or Good Display 12.48 b/w panel GDEW1248T3 or b/w/r panel GDEY1248Z51
-// general constructor for use with all parameters, e.g. for Waveshare ESP32 driver board mounted on connection board
-GxEPD2_DISPLAY_CLASS < GxEPD2_DRIVER_CLASS, MAX_HEIGHT(GxEPD2_DRIVER_CLASS) > display(GxEPD2_DRIVER_CLASS(/*sck=*/ 13, /*miso=*/ 12, /*mosi=*/ 14,
-	/*cs_m1=*/ 23, /*cs_s1=*/ 22, /*cs_m2=*/ 16, /*cs_s2=*/ 19,
-	/*dc1=*/ 25, /*dc2=*/ 17, /*rst1=*/ 33, /*rst2=*/ 5,
-	/*busy_m1=*/ 32, /*busy_s1=*/ 26, /*busy_m2=*/ 18, /*busy_s2=*/ 4));
-#endif
 #undef MAX_DISPLAY_BUFFER_SIZE
 #undef MAX_HEIGHT
 #endif


### PR DESCRIPTION
Summary
Wires the E-Ink BUSY and RST pins and removes the FreeRTOS rendering workaround for hardware that has them connected. A compile-time fallback keeps the FreeRTOS task path intact for builds without the pins wired.

Changes
Hardware – BUSY and RST pins wired
RST is connected to GPIO26, BUSY to GPIO25. GxEPD2 now uses the real BUSY signal instead of a fixed blocking delay, reducing E-Ink refresh wait time from ~2–3s to ~500ms.
Compile-time fallback
EPD_PIN_RST and EPD_PIN_BUSY are defined in Configuration.h. Setting either to -1 re-enables the FreeRTOS task path, making the firmware usable on hardware without these pins wired.
GxEPD2_display_selection_new_style.h cleaned up
Removed irrelevant board variants (GxEPD2_1248, LOLIN_D32_PRO). All four EPD pins now reference defines from Configuration.h. File reduced from 90 to ~45 lines.
PROJECT_SUMMARY.md updated
Hardware table, E-Ink section, and project structure updated to reflect BUSY/RST wiring, pin fallback behavior, and new files.