### PR TITLE
2611 bugfix

### DIFF
--- a/data/static/index.htm
+++ b/data/static/index.htm
@@ -9,12 +9,17 @@
 <body>
 <div class="container">
     <h1>{{deviceName}}</h1>
-    <div class="nav">
-        <a href="/status" class="button">Status</a>
-        <a href="/json" class="button">JSON</a>
-        <a href="/sensorsettings" class="button">Sensor Settings</a>
-        <a href="/WLAN" class="button">WLAN Settings</a>
-        <a href="/mqtt" class="button">MQTT Settings</a>
+    <div class="nav-group">
+        <div class="nav">
+            <a href="/status" class="button">Status</a>
+            <a href="/json" class="button">JSON</a>
+        </div>
+        <div class="nav-label">Settings</div>
+        <div class="nav">
+            <a href="/sensorsettings" class="button">Sensor</a>
+            <a href="/WLAN" class="button">WLAN</a>
+            <a href="/mqtt" class="button">MQTT</a>
+        </div>
     </div>
     <div class="content">
         <div id="warningBanner" style="display:none;background:#fff3cd;border:1px solid #ffc107;border-radius:5px;padding:15px;margin-top:20px;">

--- a/data/static/index.htm
+++ b/data/static/index.htm
@@ -14,11 +14,10 @@
             <a href="/status" class="button">Status</a>
             <a href="/json" class="button">JSON</a>
         </div>
-        <div class="nav-label">Settings</div>
         <div class="nav">
-            <a href="/sensorsettings" class="button">Sensor</a>
-            <a href="/WLAN" class="button">WLAN</a>
-            <a href="/mqtt" class="button">MQTT</a>
+            <a href="/sensorsettings" class="button">Sensor Settings</a>
+            <a href="/WLAN" class="button">WLAN Settings</a>
+            <a href="/mqtt" class="button">MQTT Settings</a>
         </div>
     </div>
     <div class="content">

--- a/data/static/style.css
+++ b/data/static/style.css
@@ -1,23 +1,34 @@
 body{font-family:Arial,Helvetica,sans-serif;margin:0;padding:0;background:#f0f0f0}
 .container{max-width:800px;margin:20px auto;padding:20px;background:#fff;border-radius:8px;box-shadow:0 2px 4px rgba(0,0,0,.1)}
-.nav{display:flex;width:100%;justify-content:space-between;align-items:stretch;gap:10px}
-.nav .button{text-decoration:none;color:#fff;background:#28a745;padding:10px 34px;border-radius:5px}
+.nav{display:flex;width:100%;flex-wrap:wrap;justify-content:flex-start;align-items:stretch;gap:8px}
+.nav .button{text-decoration:none;color:#fff;background:#28a745;padding:10px 16px;border-radius:5px;flex:1 1 auto;text-align:center;min-width:0;box-sizing:border-box}
 .nav .button:hover,.btn:hover{background:#218838}
 .content h1{font-size:24px;margin:20px 0}
 .content h2{font-size:18px;margin:20px 0 10px}
-.btn{background:#28a745;color:#fff;padding:10px 20px;border:none;border-radius:5px;cursor:pointer;width:165px;font-size:105%;margin-top:20px}
+.btn{background:#28a745;color:#fff;padding:10px 20px;border:none;border-radius:5px;cursor:pointer;width:100%;max-width:220px;font-size:105%;margin-top:20px;box-sizing:border-box}
 .footer{text-align:center;margin-top:20px;font-size:14px;color:#666}
-.form-row{display:flex;align-items:center;margin-bottom:15px}
+.form-row{display:flex;flex-wrap:wrap;align-items:center;margin-bottom:15px;gap:6px}
 .form-row label{display:inline-block;width:220px;font-size:14px;color:#333;flex-shrink:0}
-.form-row input[type=text],.form-row input[type=password],.form-row input[type=number]{padding:5px;font-size:14px;border:1px solid #ccc;border-radius:4px;width:220px;box-sizing:border-box}
+.form-row input[type=text],.form-row input[type=password],.form-row input[type=number]{padding:5px;font-size:14px;border:1px solid #ccc;border-radius:4px;width:220px;max-width:100%;box-sizing:border-box}
 .form-row input[type=checkbox]{transform:scale(1.2)}
-.form-row input[type=range]{width:200px}
+.form-row input[type=range]{width:200px;max-width:100%}
 .form-feedback{font-size:14px;margin-top:8px;height:18px}
 .form-feedback.success{color:#28a745}
 .form-feedback.error{color:#dc3545}
-.status-item{display:flex;flex-direction:row;padding-bottom:10px;align-items:center}
-.status-item .title{font-weight:bold;font-size:16px;color:#333;width:220px;flex-shrink:0}
-.status-item .data{color:#555;width:130px;flex-shrink:0}
-.status-item .status-indicator{width:20px;height:20px;border-radius:30%;margin-right:10px}
-.status-item .description{font-size:.9em;color:#666;line-height:1.4}
+.status-item{display:flex;flex-wrap:wrap;flex-direction:row;padding-bottom:10px;align-items:center;gap:4px}
+.status-item .title{font-weight:bold;font-size:16px;color:#333;width:180px;flex-shrink:0}
+.status-item .data{color:#555;width:110px;flex-shrink:0}
+.status-item .status-indicator{width:20px;height:20px;border-radius:30%;margin-right:6px;flex-shrink:0}
+.status-item .description{font-size:.9em;color:#666;line-height:1.4;min-width:0}
 .show-password-button{background:none;border:1px solid #ccc;border-radius:4px;cursor:pointer;padding:3px 6px;margin-left:5px;vertical-align:middle}
+@media(max-width:480px){
+.container{margin:8px;padding:14px;border-radius:6px}
+.nav .button{padding:10px 8px;font-size:14px}
+.content h1{font-size:20px}
+.form-row label{width:100%}
+.form-row input[type=text],.form-row input[type=password],.form-row input[type=number]{width:100%}
+.form-row input[type=range]{width:100%}
+.btn{max-width:100%;width:100%}
+.status-item .title{width:100%;margin-bottom:2px}
+.status-item .data{width:auto}
+}

--- a/data/static/style.css
+++ b/data/static/style.css
@@ -21,6 +21,9 @@ body{font-family:Arial,Helvetica,sans-serif;margin:0;padding:0;background:#f0f0f
 .status-item .status-indicator{width:20px;height:20px;border-radius:30%;margin-right:6px;flex-shrink:0}
 .status-item .description{font-size:.9em;color:#666;line-height:1.4;min-width:0}
 .show-password-button{background:none;border:1px solid #ccc;border-radius:4px;cursor:pointer;padding:3px 6px;margin-left:5px;vertical-align:middle}
+.nav-group{display:flex;flex-direction:column;gap:8px}
+.nav-label{font-size:13px;color:#666;margin-top:4px}
+.nav .button{flex:1 1 0;text-align:center}
 @media(max-width:480px){
 .container{margin:8px;padding:14px;border-radius:6px}
 .nav .button{padding:10px 8px;font-size:14px}

--- a/data/static/style.css
+++ b/data/static/style.css
@@ -17,7 +17,7 @@ body{font-family:Arial,Helvetica,sans-serif;margin:0;padding:0;background:#f0f0f
 .form-feedback.error{color:#dc3545}
 .status-item{display:flex;flex-wrap:wrap;flex-direction:row;padding-bottom:10px;align-items:center;gap:4px}
 .status-item .title{font-weight:bold;font-size:16px;color:#333;width:180px;flex-shrink:0}
-.status-item .data{color:#555;width:110px;flex-shrink:0}
+.status-item .data{color:#555;min-width:110px;flex-shrink:0;white-space:nowrap}
 .status-item .status-indicator{width:20px;height:20px;border-radius:30%;margin-right:6px;flex-shrink:0}
 .status-item .description{font-size:.9em;color:#666;line-height:1.4;min-width:0}
 .show-password-button{background:none;border:1px solid #ccc;border-radius:4px;cursor:pointer;padding:3px 6px;margin-left:5px;vertical-align:middle}

--- a/data/static/style.css
+++ b/data/static/style.css
@@ -22,7 +22,6 @@ body{font-family:Arial,Helvetica,sans-serif;margin:0;padding:0;background:#f0f0f
 .status-item .description{font-size:.9em;color:#666;line-height:1.4;min-width:0}
 .show-password-button{background:none;border:1px solid #ccc;border-radius:4px;cursor:pointer;padding:3px 6px;margin-left:5px;vertical-align:middle}
 .nav-group{display:flex;flex-direction:column;gap:8px}
-.nav-label{font-size:13px;color:#666;margin-top:4px}
 .nav .button{flex:1 1 0;text-align:center}
 @media(max-width:480px){
 .container{margin:8px;padding:14px;border-radius:6px}

--- a/src/DataCO2.cpp
+++ b/src/DataCO2.cpp
@@ -1,77 +1,27 @@
 #include "DataCO2.h"
 
-int DataCO2::getRegular() const
-{
-    return regular;
-}
+int DataCO2::getRegular() const {return regular;}
+void DataCO2::setRegular(int regular) {DataCO2::regular = regular;}
 
-void DataCO2::setRegular(int regular)
-{
-    DataCO2::regular = regular;
-}
+unsigned int DataCO2::getRaw() const {return raw;}
+void DataCO2::setRaw(unsigned int raw) {DataCO2::raw = raw;}
 
-unsigned int DataCO2::getRaw() const
-{
-    return raw;
-}
+int DataCO2::getLimited() const {return limited;}
+void DataCO2::setLimited(int limited) {DataCO2::limited = limited;}
 
-void DataCO2::setRaw(unsigned int raw)
-{
-    DataCO2::raw = raw;
-}
+int DataCO2::getBackground() const {return background;}
+void DataCO2::setBackground(int background) {DataCO2::background = background;}
 
-int DataCO2::getLimited() const
-{
-    return limited;
-}
+byte DataCO2::getTempAdjustment() const {return tempAdjustment;}
+void DataCO2::setTempAdjustment(byte tempAdjustment) {DataCO2::tempAdjustment = tempAdjustment;}
 
-void DataCO2::setLimited(int limited)
-{
-    DataCO2::limited = limited;
-}
+float DataCO2::getTemperature() const {return temperature;}
+void DataCO2::setTemperature(float temperature) {DataCO2::temperature = temperature;}
 
-int DataCO2::getBackground() const
-{
-    return background;
-}
-
-void DataCO2::setBackground(int background)
-{
-    DataCO2::background = background;
-}
-
-byte DataCO2::getTempAdjustment() const
-{
-    return tempAdjustment;
-}
-
-void DataCO2::setTempAdjustment(byte tempAdjustment)
-{
-    DataCO2::tempAdjustment = tempAdjustment;
-}
-
-float DataCO2::getTemperature() const
-{
-    return temperature;
-}
-
-void DataCO2::setTemperature(float temperature)
-{
-    DataCO2::temperature = temperature;
-}
-
-byte DataCO2::getAccuracy() const
-{
-    return accuracy;
-}
-
-void DataCO2::setAccuracy(byte accuracy)
-{
-    DataCO2::accuracy = accuracy;
-}
+byte DataCO2::getAccuracy() const {return accuracy;}
+void DataCO2::setAccuracy(byte accuracy) {DataCO2::accuracy = accuracy;}
 
 DataCO2::DataCO2() {}
-
 DataCO2::DataCO2(int regular, unsigned int raw, int limited, int background, byte tempAdjustment, float temperature,
                  byte accuracy) : regular(regular), raw(raw), limited(limited), background(background),
                                   tempAdjustment(tempAdjustment), temperature(temperature), accuracy(accuracy) {}

--- a/src/EPDHandler.cpp
+++ b/src/EPDHandler.cpp
@@ -179,9 +179,10 @@ void EPDHandler::printLayout(const DataCO2 &co2, const Bsec &bme_data, const Str
 
 void EPDHandler::updateEPD(const DataCO2 &co2, const Bsec &bme_data, const String &epd_date, const String &epd_time, const String &wlan_ssid, const String &ip_address, unsigned long currentSeconds)
 {
-    if (currentSeconds - _lastRunSeconds < (unsigned long)configHandler.getConfigInterval("intervalEPD"))
+    if (!_forceRender && currentSeconds - _lastRunSeconds < (unsigned long)configHandler.getConfigInterval("intervalEPD"))
         return;
 
+    _forceRender = false;
     _lastRunSeconds = currentSeconds;
     bool bmeOk  = BME680Handler::getInstance().isSensorOk();
     bool wifiOk = (WiFi.status() == WL_CONNECTED);
@@ -260,8 +261,7 @@ void EPDHandler::epdWipeTask(void *pvParameters)
 
 void EPDHandler::forceRefresh()
 {
-    _lastRunSeconds = 0;
+    _forceRender = true;
     _wiped = false;
-    _pendingRefresh = true;
     _taskRunning = false;
 }

--- a/src/EPDHandler.cpp
+++ b/src/EPDHandler.cpp
@@ -263,4 +263,5 @@ void EPDHandler::forceRefresh()
     _lastRunSeconds = 0;
     _wiped = false;
     _pendingRefresh = true;
+    _taskRunning = false;
 }

--- a/src/EPDHandler.cpp
+++ b/src/EPDHandler.cpp
@@ -92,7 +92,9 @@ void EPDHandler::printLayout(const DataCO2 &co2, const Bsec &bme_data, const Str
     display.setFullWindow();
     display.setRotation(l.rotation);
 
-    uint16_t color_temp = getAlertColor(bme_data.temperature, 26);
+    float temperature = bme_data.temperature + configHandler.getConfigSensor("tempOffset") / 10.0f;
+
+    uint16_t color_temp = getAlertColor(temperature, 26);
     uint16_t color_hum  = getAlertColor(bme_data.humidity, 70);
     uint16_t color_iaq = getAlertColor(bme_data.iaq, 300);
     uint16_t color_co2 = getAlertColor(co2.getRegular(), 1500);
@@ -103,6 +105,13 @@ void EPDHandler::printLayout(const DataCO2 &co2, const Bsec &bme_data, const Str
     // Left column icons
     display.drawInvertedBitmap(l.colL_icon, l.rowTop - 20, bitmap_temp, 24, 24, color_temp);
     display.drawInvertedBitmap(l.colL_icon, l.rowBot - 20, bitmap_hum,  24, 24, color_hum);
+
+    // Left column values: Temperature (top), Humidity (bottom)
+    if (bmeOk)
+    {
+        printValue(buffer, l.colL_value, l.rowTop, color_temp, temperature);
+        display.drawInvertedBitmap(l.colL_icon, l.rowBot - 20, bitmap_hum,  24, 24, color_hum);
+    }
 
     // Left column values: Temperature (top), Humidity (bottom)
     if (bmeOk)

--- a/src/EPDHandler.h
+++ b/src/EPDHandler.h
@@ -97,6 +97,7 @@ private:
     unsigned long _lastRunSeconds = 0;
     bool _wiped = false;
     bool _pendingRefresh = false;
+    bool _forceRender = false;
     
 };
 

--- a/src/LEDHandler.cpp
+++ b/src/LEDHandler.cpp
@@ -78,8 +78,8 @@ void LEDHandler::ledStatusWiFi()
 
 void LEDHandler::ledStatusBME()
 {
-	//long temperature = bmedata.temperature + TEMPERATUR_OFFSET;
-	/*if (temperature)
+	long temperature = bmedata.temperature + TEMPERATUR_OFFSET;
+	if (temperature)
 	{
 		if (temperature < 12) // colder
 		{
@@ -125,7 +125,7 @@ void LEDHandler::ledStatusBME()
 		{
 			setSectionColor(LED_TEMP, CRGB::Magenta);
 		}
-	}*/
+	}
 
 	if (!BME680Handler::getInstance().isSensorOk())
     {
@@ -136,66 +136,6 @@ void LEDHandler::ledStatusBME()
         return;
     }
     setSectionColor(LED_SENSORSTATE, CRGB::Green);
-
-    if (bmedata.humidity)
-    {
-        if (bmedata.humidity < 10) // Extremely dry
-        {
-            setSectionColor(LED_HUM, CRGB::DarkRed);
-        }
-        else if (bmedata.humidity < 20) // Very dry
-        {
-            setSectionColor(LED_HUM, CRGB::Red);
-        }
-        else if (bmedata.humidity < 25) // Dry
-        {
-            setSectionColor(LED_HUM, CRGB::OrangeRed);
-        }
-        else if (bmedata.humidity < 30) // Slightly dry
-        {
-            setSectionColor(LED_HUM, CRGB::Orange);
-        }
-        else if (bmedata.humidity < 35) // Normal dry
-        {
-            setSectionColor(LED_HUM, CRGB::Yellow);
-        }
-        else if (bmedata.humidity < 40) // Comfortable
-        {
-            setSectionColor(LED_HUM, CRGB::GreenYellow);
-        }
-        else if (bmedata.humidity < 45) // Optimal
-        {
-            setSectionColor(LED_HUM, CRGB::Green);
-        }
-        else if (bmedata.humidity < 50) // Slightly humid
-        {
-            setSectionColor(LED_HUM, CRGB::SeaGreen);
-        }
-        else if (bmedata.humidity < 55) // Humid
-        {
-            setSectionColor(LED_HUM, CRGB::LightBlue);
-        }
-        else if (bmedata.humidity < 60) // Very humid
-        {
-            setSectionColor(LED_HUM, CRGB::Blue);
-        }
-        else if (bmedata.humidity < 65) // Extremely humid
-        {
-            setSectionColor(LED_HUM, CRGB::DarkBlue);
-        }
-        else if (bmedata.humidity < 70) // Wet
-        {
-            setSectionColor(LED_HUM, CRGB::Purple);
-        }
-        else if (bmedata.humidity < 80) // Very wet
-        {
-            setSectionColor(LED_HUM, CRGB::Magenta);
-        }
-        else // Saturated
-        {
-            setSectionColor(LED_HUM, CRGB::White);
-        }
-	}
 }
 
 void LEDHandler::ledStatusCO2()

--- a/src/LEDsection.h
+++ b/src/LEDsection.h
@@ -5,7 +5,7 @@
 enum SectionName
 {
 	//LED_TEMP,
-	LED_HUM,
+	LED_TEMP,
 	LED_WLANCONNECT,
 	LED_SENSORSTATE,
 	LED_CO2,

--- a/src/WebServerHandler.cpp
+++ b/src/WebServerHandler.cpp
@@ -221,7 +221,8 @@ void WebServerHandler::handle_page_wlan(AsyncWebServerRequest *request)
 	file.close();
 
 	content.replace("{{deviceName}}", DeviceName);
-	request->send(200, "text/html", content);
+    content.replace("{{ssid}}", ssid);
+    request->send(200, "text/html", content);
 }
 
 void WebServerHandler::handle_page_settings(AsyncWebServerRequest *request)

--- a/src/WebServerHandler.cpp
+++ b/src/WebServerHandler.cpp
@@ -46,18 +46,7 @@ void WebServerHandler::start()
 	server.on("/api/system/status", HTTP_GET, [this](AsyncWebServerRequest *request) {handle_api_system_status(request); });
 
 	server.on("/api/epd/refresh", HTTP_POST, [this](AsyncWebServerRequest *request) {
-		EPDHandler &epd = EPDHandler::getInstance();
-		epd.forceRefresh();
-		if (configHandler.getConfigSwitch("switchEPD"))
-		{
-			String wlan_ssid = WiFi.SSID();
-			String ip_address = WiFi.localIP().toString();
-			epd.updateEPD(co2data, bmedata, acDate.substring(0, 10), acDate.substring(11, 16), wlan_ssid, ip_address, ULONG_MAX);
-		}
-		else
-		{
-			epd.wipeDisplay();
-		}
+		EPDHandler::getInstance().forceRefresh();
 		request->send(200, "text/plain", "ok");
 	});
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -192,6 +192,7 @@ void loop()
         String wlan_ssid = WiFi.SSID();
         String ip_address = WiFi.localIP().toString();
         epdHandler.updateEPD(mhz19Readout, bme_data, localTime("%Y.%m.%d"), localTime("%H:%M"), wlan_ssid, ip_address, currentSeconds);
+        epdHandler.clearPendingRefresh();
     }
     else
     {


### PR DESCRIPTION
Mobile UI Improvements
The web interface is now responsive and works correctly on phones and small screens. Navigation buttons on the index page wrap instead of overflowing off-screen, and are now grouped into two rows: one for Status/JSON and one for Settings. All buttons in a row share equal width. Form labels and inputs stack vertically on narrow screens. Long values like time and timezone no longer break into multiple lines in the status view.
E-Ink Display: Temperature Offset Applied
The temperature offset configured in the sensor settings was correctly saved to NVS but never applied to the value shown on the E-Ink display. The display now shows the corrected temperature, consistent with what is reported via Serial and JSON. The alert color threshold for temperature also uses the corrected value.
E-Ink Display: Refresh Button Fixed
The "Refresh Display" button in the sensor settings did not trigger a display update. Three independent bugs were responsible:

Early boot block – The refresh mechanism relied on resetting an internal timer to zero, but if the device had been running for less than 15 minutes (the default EPD update interval), the interval check still blocked the render. The fix uses a dedicated flag that bypasses the interval check entirely.
Concurrent access – The refresh was triggered directly from the web server context, which ran in parallel with the main loop, both accessing the SPI bus simultaneously. The fix moves all rendering exclusively into the main loop.
Wrong render path – The display was always rendered via a FreeRTOS background task, even when the hardware BUSY pin is connected and a direct synchronous call is correct.