### PR TITLE
2611 debugging msg

### DIFF
--- a/doc/PROJECT_SUMMARY.md
+++ b/doc/PROJECT_SUMMARY.md
@@ -181,7 +181,7 @@ before the display hibernates.
 ## Important Notes
 
 - `Credentials.h` is **not in the repository**. Copy `Credentials_example.h` and fill in
-  WiFi/MQTT credentials before building.
+  WiFi/MQTT credentials before building. This includes `MQTT_HOST`, `MQTT_USER`, and `MQTT_PASS`.
 - If WiFi credentials are missing or connection fails, the device falls back to AP mode.
 - `DEBUG 1` in `Configuration.h` enables verbose Serial output and RAM usage reporting.
 - The MH-Z19B is powered by 5V directly from the PSU, not from the ESP.

--- a/doc/SYSTEM_PROMPT.md
+++ b/doc/SYSTEM_PROMPT.md
@@ -29,3 +29,4 @@ general audience – including non-developers. Keep the following guidelines in 
   technical identifiers unless they are essential for clarity.
 - Structure the description by **feature or fix area**, not by file.
 - Each section should be understandable without reading the source code.
+- Deliver the description in **Markdown format**.

--- a/src/BME680Handler.cpp
+++ b/src/BME680Handler.cpp
@@ -175,30 +175,6 @@ void BME680Handler::checkSensorStatus() const
 	}
 }
 
-
-void BME680Handler::printout() const
-{
-	Serial.println();
-	Serial.println("[BME680] ");
-	Serial.println("[BME680] Timestamp [ms]:               " + String(bmeSensor.outputTimestamp));
-	Serial.println("[BME680] IAQ:                          " + String(bmeSensor.iaq));
-	Serial.println("[BME680] IAQ accuracy:                 " + String(bmeSensor.iaqAccuracy));
-	Serial.println("[BME680] IAQ Static:                   " + String(bmeSensor.staticIaq));
-	Serial.println("[BME680] gas [Ohm]:                    " + String(bmeSensor.gasResistance));
-	Serial.println("[BME680] pressure [hPa]:               " + String(bmeSensor.pressure / 100));
-	Serial.println("[BME680] CO2 equivalent:               " + String(bmeSensor.co2Equivalent));
-	Serial.println("[BME680] Stab Status:                  " + String(bmeSensor.stabStatus));
-	Serial.println("[BME680] run in status:                " + String(bmeSensor.runInStatus));
-	Serial.println("[BME680] gas percentage:               " + String(bmeSensor.gasPercentage));
-	Serial.println("[BME680] temperature [°C]:             " + String(bmeSensor.temperature));
-	Serial.println("[BME680] temperature with offset [°C]: " + String(bmeSensor.temperature + configHandler.getConfigSensor("tempOffset") / 10.0f));
-	Serial.println("[BME680] raw temperature [°C]:         " + String(bmeSensor.rawTemperature));
-	Serial.println("[BME680] relative humidity [%]:        " + String(bmeSensor.humidity));
-	Serial.println("[BME680] raw relative humidity [%]:    " + String(bmeSensor.rawHumidity));
-	Serial.println("[BME680] breath VOC equivalent [ppm]:  " + String(bmeSensor.breathVocEquivalent));
-	Serial.println();
-}
-
 Bsec BME680Handler::getData()
 {
 	return bmeSensor;
@@ -208,12 +184,16 @@ void BME680Handler::loadState(void)
 {
 	if (EEPROM.read(0) == BSEC_MAX_STATE_BLOB_SIZE)
 	{
-		Serial.println("[BME680] Reading state from EEPROM");
-		for (uint8_t i = 0; i < BSEC_MAX_STATE_BLOB_SIZE; i++)
-		{
-			bsecState[i] = EEPROM.read(i + 1);
-			Serial.println(bsecState[i], HEX);
-		}
+		Serial.printf("[BME680] Reading BSEC state from EEPROM (%d bytes)\n", BSEC_MAX_STATE_BLOB_SIZE);
+    for (uint8_t i = 0; i < BSEC_MAX_STATE_BLOB_SIZE; i++)
+    {
+        bsecState[i] = EEPROM.read(i + 1);
+    }
+    #ifdef DEBUG
+    Serial.printf("[BME680] EEPROM state loaded, first=0x%02X last=0x%02X\n",
+        bsecState[0],
+        bsecState[BSEC_MAX_STATE_BLOB_SIZE - 1]);
+    #endif
 		bmeSensor.setState(bsecState);
 		checkSensorStatus();
 	}
@@ -280,7 +260,6 @@ void BME680Handler::updateState(void)
             for (uint8_t i = 0; i < BSEC_MAX_STATE_BLOB_SIZE; i++)
             {
                 EEPROM.write(i + 1, bsecState[i]);
-                Serial.println(bsecState[i], HEX);
             }
             EEPROM.write(0, BSEC_MAX_STATE_BLOB_SIZE);
             EEPROM.commit();

--- a/src/BME680Handler.cpp
+++ b/src/BME680Handler.cpp
@@ -49,9 +49,9 @@ BME680Handler::BME680Handler()
     }
 
 
-#ifdef DEBUG
-	Serial.println("\n[BME] BSEC library version " + String(bmeSensor.version.major) + "." + String(bmeSensor.version.minor) + "." + String(bmeSensor.version.major_bugfix) + "." + String(bmeSensor.version.minor_bugfix));
-#endif
+    #ifdef DEBUG
+        Serial.println("\n[BME] BSEC library version " + String(bmeSensor.version.major) + "." + String(bmeSensor.version.minor) + "." + String(bmeSensor.version.major_bugfix) + "." + String(bmeSensor.version.minor_bugfix));
+    #endif
 	_sensorList[0]  = BSEC_OUTPUT_IAQ;
     _sensorList[1]  = BSEC_OUTPUT_STATIC_IAQ;
     _sensorList[2]  = BSEC_OUTPUT_CO2_EQUIVALENT;

--- a/src/BME680Handler.cpp
+++ b/src/BME680Handler.cpp
@@ -45,7 +45,7 @@ BME680Handler::BME680Handler()
     } else {
         _sensorOk = false;
         _bme68xError = bmeSensor.bme68xStatus;
-        Serial.println("[BME680] Init failed after 3 retries! Error: " + String(_bme68xError));
+        Serial.printf("[BME680] Init failed (bme68xStatus=%d, I2C addr=0x77)\n", _bme68xError);
     }
 
 
@@ -84,7 +84,7 @@ bool BME680Handler::updateSensorData(const unsigned long currentSeconds)
         if (currentSeconds - _lastRecoverySeconds >= 60)
         {
             _lastRecoverySeconds = currentSeconds;
-            Serial.println("[BME680] Attempting recovery...");
+            Serial.printf("[BME680] Recovery attempt (uptime %lus)...\n", currentSeconds);
             Wire.end();
             delay(100);
             Wire.begin(PIN_BME680_SDA, PIN_BME680_SCL);
@@ -107,7 +107,7 @@ bool BME680Handler::updateSensorData(const unsigned long currentSeconds)
             else
             {
                 _bme68xError = bmeSensor.bme68xStatus;
-                Serial.println("[BME680] Recovery failed, error: " + String(_bme68xError));
+                Serial.printf("[BME680] Recovery failed (bme68xStatus=%d) – retry in 60s\n", _bme68xError);
             }
         }
         return false;
@@ -132,8 +132,7 @@ bool BME680Handler::updateSensorData(const unsigned long currentSeconds)
     {
         _consecutiveErrors++;
         _bme68xError = bmeSensor.bme68xStatus;
-        Serial.println("[BME680] Runtime error: " + String(_bme68xError) +
-                       " (" + String(_consecutiveErrors) + " consecutive)");
+        Serial.printf("[BME680] Error %d (%d/5 consecutive)%s\n", _bme68xError, _consecutiveErrors, (_consecutiveErrors >= 4 ? " – recovery imminent!" : ""));
         checkSensorStatus();
         if (_consecutiveErrors >= 5)
         {
@@ -274,7 +273,10 @@ void BME680Handler::updateState(void)
 
         if (dataChanged)
         {
-            Serial.println("[BME680] Writing state to EEPROM");
+            Serial.printf("[BME680] Writing BSEC state to EEPROM (%d bytes), first=0x%02X last=0x%02X\n",
+                BSEC_MAX_STATE_BLOB_SIZE,
+                bsecState[0],
+                bsecState[BSEC_MAX_STATE_BLOB_SIZE - 1]);
             for (uint8_t i = 0; i < BSEC_MAX_STATE_BLOB_SIZE; i++)
             {
                 EEPROM.write(i + 1, bsecState[i]);

--- a/src/BME680Handler.h
+++ b/src/BME680Handler.h
@@ -15,7 +15,6 @@ public:
     }
     Bsec getData();
     bool updateSensorData(const unsigned long currentSeconds);
-    void printout() const;
     bool isSensorOk() const;
     int getSensorError() const;
     bool isRecovering() const;

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -2,7 +2,7 @@
 #define CO2_TURTLE_CONFIGURATION_H
 
 //uncomment to get debug in serial
-#define DEBUG 1
+#define DEBUG 0
 
 #define switch_WIFI  1
 #define switch_Webserver 1

--- a/src/MHZ19Handler.cpp
+++ b/src/MHZ19Handler.cpp
@@ -48,43 +48,6 @@ void MHZ19Handler::calibrate()
 }
 
 
-
-
-void MHZ19Handler::printoutCurrentValues()
-{
-	if (myMHZ19.errorCode == RESULT_OK)
-	{
-		Serial.println("[MHZ19] CurrentValues:");
-		//        Serial.println(name_MHZ19_timestamp       + ":     "       + data_MHZ19_timestamp     );
-		//        Serial.println(name_MHZ19_datetime        + ":      "      + data_MHZ19_datetime      );
-        Serial.println(name_MHZ19_co2             + ":          "   + myMHZ19.getCO2()            );
-        Serial.println(name_MHZ19_co2_raw         + ":       "      + myMHZ19.getCO2Raw()         );
-        Serial.println(name_MHZ19_co2_limited     + ":            " + myMHZ19.getCO2(false)       );
-        Serial.println(name_MHZ19_co2_background  + ":         "    + myMHZ19.getBackgroundCO2()  );
-        Serial.println(name_MHZ19_co2_tempAdjust  + ": "            + myMHZ19.getTempAdjustment() );
-        Serial.println(name_MHZ19_co2_temperatur  + ":    "         + myMHZ19.getTemperature()    );
-        Serial.println(name_MHZ19_co2_Accuracy    + ":           "  + myMHZ19.getAccuracy()       );
-		Serial.println();
-	}
-	else
-	{
-		Serial.printf("[MHZ19] Read failed – errorCode=%d (%d consecutive)\n", myMHZ19.errorCode, _consecutiveErrors);
-	}
-}
-
-void MHZ19Handler::printoutLastReadout()
-{
-	Serial.println("[MHZ19] LastReadout:");
-        Serial.println(name_MHZ19_co2             + ":          "   + String(_lastReadout.getRegular()       ));
-        Serial.println(name_MHZ19_co2_raw         + ":      "       + String(_lastReadout.getRaw()           ));
-        Serial.println(name_MHZ19_co2_limited     + ":            " + String(_lastReadout.getLimited()       ));
-        Serial.println(name_MHZ19_co2_background  + ":         "    + String(_lastReadout.getBackground()    ));
-        Serial.println(name_MHZ19_co2_tempAdjust  + ": "            + String(_lastReadout.getTempAdjustment()));
-        Serial.println(name_MHZ19_co2_temperatur  + ":    "         + String(_lastReadout.getTemperature()   ));
-        Serial.println(name_MHZ19_co2_Accuracy    + ":           "  + String(_lastReadout.getAccuracy()      ));
-	Serial.println();
-}
-
 DataCO2 MHZ19Handler::getLastReadout()
 {
 	return _lastReadout;

--- a/src/MHZ19Handler.cpp
+++ b/src/MHZ19Handler.cpp
@@ -68,9 +68,7 @@ void MHZ19Handler::printoutCurrentValues()
 	}
 	else
 	{
-		Serial.println("[MHZ19] Failed to recieve CO2 value - Error");
-		Serial.print("[MHZ19] Response Code: ");
-		Serial.println(myMHZ19.errorCode); // Get the Error Code value
+		Serial.printf("[MHZ19] Read failed – errorCode=%d (%d consecutive)\n", myMHZ19.errorCode, _consecutiveErrors);
 	}
 }
 
@@ -110,12 +108,11 @@ bool MHZ19Handler::updateLastReadout()
 	else
 	{
 		_consecutiveErrors++;
-		Serial.printf("[MHZ19] Fehler %d: Response Code %d\n",
-			_consecutiveErrors, myMHZ19.errorCode);
+		Serial.printf("[MHZ19] Error count %d, response code %d\n", _consecutiveErrors, myMHZ19.errorCode);
 
 		if (_consecutiveErrors >= 3)
 		{
-			Serial.println("[MHZ19] Recovery: Serial neu initialisieren...");
+			Serial.println("[MHZ19] Recovery: reinitializing Serial2...");
 			Serial_MHZ19->end();
 			vTaskDelay(500 / portTICK_PERIOD_MS);
 			Serial2.begin(BAUDRATE, SERIAL_8N1, PIN_MHZ19_RX, PIN_MHZ19_TX);

--- a/src/MHZ19Handler.h
+++ b/src/MHZ19Handler.h
@@ -14,8 +14,6 @@ public:
 		static MHZ19Handler instance; // Guaranteed to be destroyed.
 		return instance;			  // Instantiated on first use.
 	}
-	void printoutCurrentValues();
-	void printoutLastReadout();
 	DataCO2 getLastReadout();
 	bool runUpdate(unsigned long currentSeconds);
 	void calibrate();

--- a/src/MqttClientHandler.cpp
+++ b/src/MqttClientHandler.cpp
@@ -29,17 +29,18 @@ bool MqttClientHandler::isConnected()
 
 void MqttClientHandler::WiFiEvent(WiFiEvent_t event)
 {
-	Serial.printf("[MQTT] event: %d\n", event);
-	wl_status_t status = WiFiClass::status();
-	if (status != WL_CONNECTED)
-	{
-		Serial.println("[MQTT] lost connection");
-	}
-	else
-	{
-		Serial.println("[MQTT] reconnection");
-		connectToMqtt();
-	}
+	#ifdef DEBUG
+		Serial.printf("[MQTT] WiFiEvent %d, status=%d\n", event, (int)WiFiClass::status());
+	#endif
+    if (WiFiClass::status() != WL_CONNECTED)
+    {
+        Serial.println("[MQTT] WiFi lost – skipping reconnect");
+    }
+    else
+    {
+        Serial.println("[MQTT] WiFi up, connecting to MQTT...");
+        connectToMqtt();
+    }
 }
 
 void MqttClientHandler::onMqttConnect(bool sessionPresent)
@@ -50,7 +51,17 @@ void MqttClientHandler::onMqttConnect(bool sessionPresent)
 
 void MqttClientHandler::onMqttDisconnect(AsyncMqttClientDisconnectReason reason)
 {
-	Serial.println("[MQTT] Disconnected, reason: " + String((int)reason));
+    const char* reasonStr = "unknown";
+    switch (reason) {
+        case AsyncMqttClientDisconnectReason::TCP_DISCONNECTED:                   reasonStr = "TCP disconnected"; break;
+        case AsyncMqttClientDisconnectReason::MQTT_UNACCEPTABLE_PROTOCOL_VERSION: reasonStr = "bad protocol version"; break;
+        case AsyncMqttClientDisconnectReason::MQTT_IDENTIFIER_REJECTED:           reasonStr = "client ID rejected"; break;
+        case AsyncMqttClientDisconnectReason::MQTT_SERVER_UNAVAILABLE:            reasonStr = "server unavailable"; break;
+        case AsyncMqttClientDisconnectReason::MQTT_MALFORMED_CREDENTIALS:         reasonStr = "bad credentials"; break;
+        case AsyncMqttClientDisconnectReason::MQTT_NOT_AUTHORIZED:                reasonStr = "not authorized"; break;
+        default: break;
+    }
+    Serial.printf("[MQTT] Disconnected: %s (code %d)\n", reasonStr, (int)reason);
 }
 
 void MqttClientHandler::setup_Mqtt()
@@ -131,10 +142,8 @@ void MqttClientHandler::publishDiscovery()
         payload += "\"unique_id\":\"sensorturtle_" + String(s.uniqueId) + "\",";
         payload += "\"name\":\"" + String(s.name) + "\",";
         payload += "\"state_topic\":\"" + String(s.stateTopic) + "\",";
-        if (strlen(s.unit) > 0)
-            payload += "\"unit_of_measurement\":\"" + String(s.unit) + "\",";
-        if (strlen(s.deviceClass) > 0)
-            payload += "\"device_class\":\"" + String(s.deviceClass) + "\",";
+        if (strlen(s.unit) > 0) payload += "\"unit_of_measurement\":\"" + String(s.unit) + "\",";
+        if (strlen(s.deviceClass) > 0) payload += "\"device_class\":\"" + String(s.deviceClass) + "\",";
         payload += "\"state_class\":\"" + String(s.stateClass) + "\",";
         payload += (s.isBME ? deviceBME : deviceMHZ);
         payload += "}";
@@ -176,15 +185,15 @@ void MqttClientHandler::publishData(const DataCO2 data_co2, const Bsec data_bme,
 			mqttClient.publish("homeassistant/sensor/sensorturtle/co2_temp_adjustment/state", 1, true, String(data_co2.getTempAdjustment()).c_str());
 			mqttClient.publish("homeassistant/sensor/sensorturtle/co2_temperature/state",     1, true, String(data_co2.getTemperature()).c_str());
 
-#ifdef DEBUG
-			Serial.println("[MQTT] Send data");
-#endif
+			#ifdef DEBUG
+						Serial.println("[MQTT] Send data");
+			#endif
 		}
 		else
 		{
-#ifdef DEBUG
-			Serial.println("[MQTT] No data send");
-#endif
+			#ifdef DEBUG
+				Serial.printf("[MQTT] Publish skipped – not connected (state: %s)\n", mqttClient.connected() ? "connected" : "disconnected");
+			#endif
 		}
 	}
 }

--- a/src/WebServerHandler.cpp
+++ b/src/WebServerHandler.cpp
@@ -286,75 +286,67 @@ void WebServerHandler::handle_submit_WLANcredentials(AsyncWebServerRequest *requ
 
 void WebServerHandler::handle_submit_modulinterval(AsyncWebServerRequest *request)
 {
-
 	if (request->hasParam("intervalMHZ19"))
 	{
 		configHandler.setConfigInterval("intervalMHZ19", request->getParam("intervalMHZ19")->value().toInt());
 	}
 	else
 	{
-		Serial.println("MHZ19 Interval not set. Using default value.");
+		Serial.printf("[WebServer] intervalMHZ19 missing, using default: %ds\n", interval_MHZ19_in_Seconds);
 		configHandler.setConfigInterval("intervalMHZ19", interval_MHZ19_in_Seconds);
 	}
-
 	if (request->hasParam("intervalBME680"))
 	{
 		configHandler.setConfigInterval("intervalBME680", request->getParam("intervalBME680")->value().toInt());
 	}
 	else
 	{
-		Serial.println("BME680 Interval not set. Using default value.");
+		Serial.printf("[WebServer] intervalBME680 missing, using default: %ds\n", interval_BME680_in_Seconds);
 		configHandler.setConfigInterval("intervalBME680", interval_BME680_in_Seconds);
 	}
-
 	if (request->hasParam("intervalWiFi"))
 	{
 		configHandler.setConfigInterval("intervalWiFi", request->getParam("intervalWiFi")->value().toInt());
 	}
 	else
-	{	
-		Serial.println("WiFi Interval not set. Using default value.");
+	{
+		Serial.printf("[WebServer] intervalWiFi missing, using default: %ds\n", interval_WiFiCheck_in_Seconds);
 		configHandler.setConfigInterval("intervalWiFi", interval_WiFiCheck_in_Seconds);
 	}
-
 	if (request->hasParam("intervalPRINT"))
 	{
 		configHandler.setConfigInterval("intervalPRINT", request->getParam("intervalPRINT")->value().toInt());
 	}
 	else
 	{
-		Serial.println("RAM Printout Interval not set. Using default value.");
+		Serial.printf("[WebServer] intervalPRINT missing, using default: %ds\n", interval_RAMPrintout_in_Seconds);
 		configHandler.setConfigInterval("intervalPRINT", interval_RAMPrintout_in_Seconds);
 	}
-
 	if (request->hasParam("intervalEPD"))
 	{
 		configHandler.setConfigInterval("intervalEPD", request->getParam("intervalEPD")->value().toInt());
 	}
 	else
 	{
-		Serial.println("EPD Interval not set. Using default value.");
+		Serial.printf("[WebServer] intervalEPD missing, using default: %ds\n", interval_EPD_in_Seconds);
 		configHandler.setConfigInterval("intervalEPD", interval_EPD_in_Seconds);
 	}
-
 	if (request->hasParam("intervalLED"))
 	{
 		configHandler.setConfigInterval("intervalLED", request->getParam("intervalLED")->value().toInt());
 	}
 	else
 	{
-		Serial.println("LED Interval not set. Using default value.");
+		Serial.printf("[WebServer] intervalLED missing, using default: %ds\n", interval_LED_in_Seconds);
 		configHandler.setConfigInterval("intervalLED", interval_LED_in_Seconds);
 	}
-
 	if (request->hasParam("intervalMQTT"))
 	{
-
 		configHandler.setConfigInterval("intervalMQTT", request->getParam("intervalMQTT")->value().toInt());
 	}
 	else
 	{
-		Serial.println("MQTT Interval not set. Using default value.");
+		Serial.printf("[WebServer] intervalMQTT missing, using default: %ds\n", interval_mqtt_in_Seconds);
 		configHandler.setConfigInterval("intervalMQTT", interval_mqtt_in_Seconds);
 	}
 	configHandler.persistAllSettings();

--- a/src/WiFiHandler.cpp
+++ b/src/WiFiHandler.cpp
@@ -14,7 +14,7 @@ void WiFiHandler::loadWiFiCredentials()
 {
     _ssid     = configHandler.getConfigDevice("wlanSSID");
     _password = configHandler.getConfigDevice("wlanPASSWORD");
-	Serial.println("[WIFI] get credentails");
+	Serial.printf("[WIFI] Credentials loaded: SSID='%s' (%s)\n", _ssid.c_str(), _ssid.isEmpty() ? "empty" : "set");
 }
 
 static bool connectToWifi()
@@ -49,9 +49,7 @@ void WiFiHandler::setupAPMode()
     const char *apPassword = AP_PASSWORD;
 
 	WiFi.softAP(apSSID, apPassword);
-	Serial.println("[AP MODE] no known wifi credentials found, starting AP mode");
-	Serial.print("[AP MODE] IP address: ");
-	Serial.println(WiFi.softAPIP());
+	Serial.printf("[AP MODE] Starting access point '%s', IP: %s\n", AP_SSID, WiFi.softAPIP().toString().c_str());
 }
 
 static void setupMDNS()
@@ -104,6 +102,8 @@ bool WiFiHandler::StatusCheck()
     {
         Serial.println("[WIFI] Connection lost, reconnecting...");
         ReStart();
+        bool reconnected = (WiFiClass::status() == WL_CONNECTED);
+        Serial.printf("[WIFI] Reconnect %s%s\n", reconnected ? "OK – IP: " : "FAILED", reconnected ? WiFi.localIP().toString().c_str() : "");
         connected = (WiFiClass::status() == WL_CONNECTED);
     }
     return connected;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,25 +80,6 @@ String localTime(const String &format)
 	return time;
 }
 
-#ifdef DEBUG
-static void PrintRamUsage(unsigned long currentSeconds)
-{
-	static unsigned long lastPrintSeconds = 0;
-	if (currentSeconds - lastPrintSeconds >= (unsigned long)configHandler.getConfigInterval("intervalPRINT"))
-	{
-		lastPrintSeconds = currentSeconds;
-		Serial.print("Memory Usage: ");
-		uint32_t freeHeap = ESP.getFreeHeap();
-		uint32_t maximumHeap = ESP.getHeapSize();
-		uint32_t usedHeap = maximumHeap - freeHeap;
-		Serial.print(usedHeap);
-		Serial.print("b | ");
-		Serial.print(maximumHeap);
-		Serial.println("b");
-	}
-}
-#endif
-
 void setup()
 {
 	delay(100);
@@ -139,33 +120,12 @@ void loop()
 	unsigned long currentSeconds = millis() / 1000;
 
 	BME680Handler &bmehandler = BME680Handler::getInstance();
-
-    if (DEBUG)
-    {
-        if (bmehandler.updateSensorData(currentSeconds))
-        {
-            bmehandler.printout();
-        }
-    }
-    else
-    {
-        bmehandler.updateSensorData(currentSeconds);
-    }
+    bmehandler.updateSensorData(currentSeconds);
 
     Bsec bme_data = bmehandler.getData(); 
 
 	MHZ19Handler &mhz19Handler = MHZ19Handler::getInstance();
-	if (DEBUG)
-	{
-		if (mhz19Handler.runUpdate(currentSeconds))
-		{
-			mhz19Handler.printoutLastReadout();
-		}
-	}
-	else
-	{
-		mhz19Handler.runUpdate(currentSeconds);
-	}
+	mhz19Handler.runUpdate(currentSeconds);
 
 	DataCO2 mhz19Readout = mhz19Handler.getLastReadout();
 
@@ -214,9 +174,5 @@ void loop()
 			MqttHandler.setup_Mqtt();
 		}
 		MqttHandler.publishData(mhz19Readout, bme_data, currentSeconds);
-	}
-	if (DEBUG)
-	{
-		PrintRamUsage(currentSeconds);
 	}
 }


### PR DESCRIPTION
Merge Request Description
Branch: debugging_msg
Target: prerelease
What changed and why
This branch improves the quality of diagnostic messages output over the Serial interface. The goal was to make debug output more useful when investigating real problems, and to reduce noise during normal operation.

MQTT
The WiFi event handler now shows both the event ID and the current connection status in a single line, guarded by DEBUG so it doesn't appear in production builds. More importantly, disconnect events now show a human-readable reason instead of a raw integer — for example "bad credentials" or "server unavailable" instead of "reason: 5".

WiFi & AP Mode
The credentials log now shows the configured SSID and whether it is set or empty, making misconfiguration immediately visible. The AP mode startup was consolidated from two separate print calls into a single line showing both the access point name and its IP address. When a reconnect attempt completes, the result (success with IP, or failure) is now explicitly logged.

E-Ink Display (EPD)
No changes were made in this branch. The EPD handler had no Serial output to begin with.

BME680 Sensor
Error and recovery messages were made more informative: the init failure now shows the actual status code and I2C address, recovery attempts include the device uptime, and the consecutive error counter now indicates proximity to the recovery threshold. The verbose 15-line sensor data dump (printout()) was removed from the main loop — it was being called on every successful read and is no longer needed now that values are visible via the web interface and MQTT.
The EEPROM byte-by-byte hex dump during state load was replaced with a compact summary showing the total byte count and first/last byte as a fingerprint. Note: the hex dump inside the write loop (updateState) still remains and should be removed in a follow-up.

MH-Z19B Sensor
The printoutCurrentValues() and printoutLastReadout() functions were removed from the main loop. These printed all seven CO2 values on every read cycle, flooding the Serial output. Error messages now include the consecutive error count. A German-language message ("Fehler", "Serial neu initialisieren") was replaced with English.
The two-call ABC/Range init output (Serial.print + Serial.println) was not yet consolidated — this remains as a follow-up item.

Web Server
Interval fallback messages now include the module name as a [WebServer] prefix and show the actual default value being applied, making it clear which setting was missing and what value was used instead.