### PR TITLE
2611 device name

### DIFF
--- a/doc/PROJECT_SUMMARY.md
+++ b/doc/PROJECT_SUMMARY.md
@@ -48,7 +48,7 @@ falls back to FreeRTOS tasks to avoid blocking the async TCP stack.
 ```
 src/
 ├── main.cpp                  – Setup and main loop
-├── Configuration.h           – Compile-time pin definitions, defaults, EPD pin config
+├── Configuration.h           – Compile-time pin definitions and NVS defaults
 ├── Credentials.h             – WiFi/MQTT credentials (not in repo, see Credentials_example.h)
 ├── BME680Handler.cpp/.h      – BSEC sensor reading, EEPROM state persistence
 ├── MHZ19Handler.cpp/.h       – CO2 sensor reading with error recovery
@@ -56,7 +56,7 @@ src/
 ├── LEDHandler.cpp/.h         – LED strip status display
 ├── LEDsection.h              – LED section definitions (enum + start/end indices)
 ├── WiFiHandler.cpp/.h        – WiFi init, reconnect, AP fallback mode
-├── WebServerHandler.cpp/.h   – Async web server, all HTTP handlers
+├── WebServerHandler.cpp/.h   – Async web server, all HTTP handlers (always active)
 ├── MqttClientHandler.cpp/.h  – MQTT publishing and Home Assistant discovery
 ├── ConfigHandler.cpp/.h      – Runtime config via NVS (Preferences)
 ├── DataCO2.cpp/.h            – Value object for MH-Z19B readings
@@ -101,6 +101,8 @@ Config is split into 5 maps:
 | Device | deviceName, timezone, wlanSSID, wlanPASSWORD, mqttHOST, mqttPORT, mqttUSER, mqttPASSWORD, mqttUSERen |
 | LED | LEDbrightness (range 2–255) |
 | Sensor | pressure (hPa), tempOffset (stored as int × 10) |
+
+**Note:** The web server is always active and is not controlled by a config switch.
 
 ---
 
@@ -175,18 +177,34 @@ before the display hibernates.
 - Publishes all sensor values at `intervalMQTT`
 - Optional user/password authentication (`mqttUSERen`)
 - Host, port, credentials fully configurable via web UI without recompiling
+- MQTT client-ID, discovery identifiers, and all state topics are derived from
+  `deviceName` (NVS) – multiple devices with identical firmware can share one broker
+  without conflict
+- Topic structure: `homeassistant/sensor/<deviceId>/<measurement>/state`
+
+---
+
+## Device Identity & Multi-Device Support
+
+On first boot, if `deviceName` in NVS still matches the compiled-in default
+(`DEVICE_NAME` in `Configuration.h`), a unique name is automatically generated
+from the default plus the last 3 bytes of the WiFi MAC address
+(e.g. `sensor-turtle-579cc0`). This name is persisted to NVS and used from
+then on as the WiFi hostname, mDNS name, and MQTT client-ID.
+
+This allows flashing identical firmware to multiple devices while still getting
+a unique identity per device in the router, mDNS, and Home Assistant – without
+any manual configuration step. The name can be changed freely via the web interface.
 
 ---
 
 ## Important Notes
 
 - `Credentials.h` is **not in the repository**. Copy `Credentials_example.h` and fill in
-  WiFi/MQTT credentials before building. This includes `MQTT_HOST`, `MQTT_USER`, and `MQTT_PASS`.
+  WiFi/MQTT credentials before building.
 - If WiFi credentials are missing or connection fails, the device falls back to AP mode.
 - `DEBUG 1` in `Configuration.h` enables verbose Serial output and RAM usage reporting.
 - The MH-Z19B is powered by 5V directly from the PSU, not from the ESP.
 - `switchEPDorientation` is stored as **Int** (not Bool) to support values 0–3.
-
----
-
-
+- All runtime values (timezone, tempOffset, pressure) are read from NVS at runtime;
+  the defines in `Configuration.h` serve only as first-boot defaults.

--- a/doc/SYSTEM_PROMPT.md
+++ b/doc/SYSTEM_PROMPT.md
@@ -30,3 +30,8 @@ general audience – including non-developers. Keep the following guidelines in 
 - Structure the description by **feature or fix area**, not by file.
 - Each section should be understandable without reading the source code.
 - Deliver the description in **Markdown format**.
+
+## How I Want Document Updates Delivered
+
+**PROJECT_SUMMARY.md** is always delivered as a complete, updated file for download.
+It is never listed in full in the chat.

--- a/src/BME680Handler.cpp
+++ b/src/BME680Handler.cpp
@@ -49,7 +49,7 @@ BME680Handler::BME680Handler()
     }
 
 
-    #ifdef DEBUG
+    #if DEBUG
         Serial.println("\n[BME] BSEC library version " + String(bmeSensor.version.major) + "." + String(bmeSensor.version.minor) + "." + String(bmeSensor.version.major_bugfix) + "." + String(bmeSensor.version.minor_bugfix));
     #endif
 	_sensorList[0]  = BSEC_OUTPUT_IAQ;
@@ -189,7 +189,7 @@ void BME680Handler::loadState(void)
     {
         bsecState[i] = EEPROM.read(i + 1);
     }
-    #ifdef DEBUG
+    #if DEBUG
     Serial.printf("[BME680] EEPROM state loaded, first=0x%02X last=0x%02X\n",
         bsecState[0],
         bsecState[BSEC_MAX_STATE_BLOB_SIZE - 1]);

--- a/src/ConfigHandler.cpp
+++ b/src/ConfigHandler.cpp
@@ -27,7 +27,7 @@ void ConfigHandler::loadAllPersistedSettings()
 		configMapforInterval["intervalLED"] = preferences.getInt("intervalLED", interval_LED_in_Seconds);
 		configMapforInterval["intervalMQTT"] = preferences.getInt("intervalMQTT", interval_mqtt_in_Seconds);
 
-		configMapforDevice["deviceName"] = preferences.getString("deviceName", DeviceName);
+		configMapforDevice["deviceName"] = preferences.getString("deviceName", DEVICE_NAME);
 		configMapforDevice["timezone"] = preferences.getString("timezone", TIMEZONE);
 		configMapforDevice["wlanSSID"] = preferences.getString("wlanSSID", WIFI_SSID);
 		configMapforDevice["wlanPASSWORD"] = preferences.getString("wlanPASSWORD", WIFI_PW);
@@ -141,7 +141,7 @@ void ConfigHandler::restoreDefaultConfiguration()
 	preferences.putInt("intervalLED", interval_LED_in_Seconds);
 	preferences.putInt("intervalMQTT", interval_mqtt_in_Seconds);
 
-	preferences.putString("deviceName", DeviceName);
+	preferences.putString("deviceName", DEVICE_NAME);
 	preferences.putString("timezone", TIMEZONE);
 	preferences.putString("wlanSSID", WIFI_SSID);
 	preferences.putString("wlanPASSWORD", WIFI_PW);

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -22,7 +22,7 @@
 #define SEALEVELPRESSURE_HPA 1015
 #define TEMPERATUR_OFFSET -3.5
 
-#define DeviceName "Turtle 08.03.2026"
+#define DEVICE_NAME "Turtle 08.03.2026"
 #define TIMEZONE "CET-1CEST,M3.5.0,M10.5.0/3"
 
 #define PIN_BME680_SDA 21

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -22,7 +22,7 @@
 #define SEALEVELPRESSURE_HPA 1015
 #define TEMPERATUR_OFFSET -3.5
 
-#define DEVICE_NAME "Turtle 08.03.2026"
+#define DEVICE_NAME "SensorTurtle"
 #define TIMEZONE "CET-1CEST,M3.5.0,M10.5.0/3"
 
 #define PIN_BME680_SDA 21

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -42,9 +42,6 @@
 #define MQTT_PORT 1883
 #define MQTT_USER_ENABLED 0
 
-
-extern const char* DeviceNameConf;
-
 // EPD hardware pins – set to -1 if not wired
 #define EPD_PIN_RST  26
 #define EPD_PIN_BUSY 25

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -5,7 +5,6 @@
 #define DEBUG 0
 
 #define switch_WIFI  1
-#define switch_Webserver 1
 #define switch_EPD 1
 #define switch_LED 1
 #define switch_MQTT 0

--- a/src/EPDHandler.cpp
+++ b/src/EPDHandler.cpp
@@ -171,7 +171,7 @@ void EPDHandler::printLayout(const DataCO2 &co2, const Bsec &bme_data, const Str
     display.print(footerStr(epd_date + " " + epd_time));
     display.drawInvertedBitmap(l.footerTurtleX, l.footerTurtleY, bitmap_turtle, 18, 18, GxEPD_RED);
     display.setCursor(l.footerNameX, l.footerNameY);
-    display.print(footerStr(String(DeviceName)));
+    display.print(footerStr(String(DEVICE_NAME)));
     display.display(false);
     display.hibernate();
     display.end();

--- a/src/LEDHandler.cpp
+++ b/src/LEDHandler.cpp
@@ -78,7 +78,7 @@ void LEDHandler::ledStatusWiFi()
 
 void LEDHandler::ledStatusBME()
 {
-	long temperature = bmedata.temperature + TEMPERATUR_OFFSET;
+	long temperature = bmedata.temperature + configHandler.getConfigSensor("tempOffset") / 10.0f;
 	if (temperature)
 	{
 		if (temperature < 12) // colder

--- a/src/MqttClientHandler.cpp
+++ b/src/MqttClientHandler.cpp
@@ -31,7 +31,7 @@ bool MqttClientHandler::isConnected()
 
 void MqttClientHandler::WiFiEvent(WiFiEvent_t event)
 {
-	#ifdef DEBUG
+	#if DEBUG
 		Serial.printf("[MQTT] WiFiEvent %d, status=%d\n", event, (int)WiFiClass::status());
 	#endif
     if (WiFiClass::status() != WL_CONNECTED)
@@ -193,13 +193,13 @@ void MqttClientHandler::publishData(const DataCO2 data_co2, const Bsec data_bme,
 			mqttClient.publish((_topicBase + "/co2_temp_adjustment/state").c_str(), 1, true, String(data_co2.getTempAdjustment()).c_str());
 			mqttClient.publish((_topicBase + "/co2_temperature/state").c_str(),     1, true, String(data_co2.getTemperature()).c_str());
 
-			#ifdef DEBUG
-						Serial.println("[MQTT] Send data");
-			#endif
+			#if DEBUG
+				Serial.println("[MQTT] Send data");
+		    #endif
 		}
 		else
 		{
-			#ifdef DEBUG
+			#if DEBUG
 				Serial.printf("[MQTT] Publish skipped – not connected (state: %s)\n", mqttClient.connected() ? "connected" : "disconnected");
 			#endif
 		}

--- a/src/MqttClientHandler.cpp
+++ b/src/MqttClientHandler.cpp
@@ -3,16 +3,18 @@
 #include "Credentials.h"
 #include <WiFi.h>
 #include "ConfigHandler.h"
+#include <AsyncMqttClient.h>
 unsigned long MqttClientHandler::_lastRunSeconds = 0;
 extern ConfigHandler &configHandler;
-
 extern "C"
 {
-#include "freertos/FreeRTOS.h"
-#include "freertos/timers.h"
+    #include "freertos/FreeRTOS.h"
+    #include "freertos/timers.h"
 }
-#include <AsyncMqttClient.h>
+
 AsyncMqttClient mqttClient;
+String MqttClientHandler::_deviceId;
+String MqttClientHandler::_topicBase;
 
 void MqttClientHandler::connectToMqtt()
 {
@@ -71,6 +73,14 @@ void MqttClientHandler::setup_Mqtt()
 	mqttClient.onConnect(onMqttConnect);
 	mqttClient.onDisconnect(onMqttDisconnect);
 
+	// Build unique device ID and topic base from NVS deviceName
+	_deviceId = configHandler.getConfigDevice("deviceName");
+	_deviceId.replace(" ", "-");
+	_deviceId.toLowerCase();
+	_topicBase = "homeassistant/sensor/" + _deviceId;
+	mqttClient.setClientId(_deviceId.c_str());
+	Serial.println("[MQTT] Client-ID: " + _deviceId);
+
 	_mqttHost = configHandler.getConfigDevice("mqttHOST");
 	int port = configHandler.getConfigDevice("mqttPORT").toInt();
 	mqttClient.setServer(_mqttHost.c_str(), port);
@@ -95,13 +105,12 @@ void MqttClientHandler::publishDiscovery()
 {
     if (!mqttClient.connected()) return;
 
-    String deviceBME = "\"device\":{\"identifiers\":[\"sensorturtle_bme680\"],\"name\":\"SensorTurtle BME680\",\"model\":\"BME680\",\"manufacturer\":\"Bosch\",\"via_device\":\"sensorturtle\"}";
-    String deviceMHZ = "\"device\":{\"identifiers\":[\"sensorturtle_mhz19\"],\"name\":\"SensorTurtle MHZ19\",\"model\":\"MH-Z19B\",\"manufacturer\":\"Winsen\",\"via_device\":\"sensorturtle\"}";
+    String deviceBME = "\"device\":{\"identifiers\":[\"" + _deviceId + "_bme680\"],\"name\":\"" + _deviceId + " BME680\",\"model\":\"BME680\",\"manufacturer\":\"Bosch\",\"via_device\":\"" + _deviceId + "\"}";
+    String deviceMHZ = "\"device\":{\"identifiers\":[\"" + _deviceId + "_mhz19\"],\"name\":\"" + _deviceId + " MHZ19\",\"model\":\"MH-Z19B\",\"manufacturer\":\"Winsen\",\"via_device\":\"" + _deviceId + "\"}";
 
     struct SensorConfig {
         const char* uniqueId;
         const char* name;
-        const char* stateTopic;
         const char* unit;
         const char* deviceClass;
         const char* stateClass;
@@ -110,38 +119,37 @@ void MqttClientHandler::publishDiscovery()
 
     SensorConfig sensors[] = {
         // BME680
-        {"temperature",         "Temperature",          "homeassistant/sensor/sensorturtle/temperature/state",          "°C",  "temperature",    "measurement", true},
-        {"temperature_offset",  "Temperature (Offset)", "homeassistant/sensor/sensorturtle/temperature_offset/state",   "°C",  "temperature",    "measurement", true},
-        {"humidity",            "Humidity",             "homeassistant/sensor/sensorturtle/humidity/state",             "%",   "humidity",       "measurement", true},
-        {"pressure",            "Air Pressure",         "homeassistant/sensor/sensorturtle/pressure/state",             "hPa", "pressure",       "measurement", true},
-        {"gas",                 "Gas Resistance",       "homeassistant/sensor/sensorturtle/gas/state",                  "Ω",   "",               "measurement", true},
-        {"iaq",                 "IAQ",                  "homeassistant/sensor/sensorturtle/iaq/state",                  "",    "",               "measurement", true},
-        {"iaq_accuracy",        "IAQ Accuracy",         "homeassistant/sensor/sensorturtle/iaq_accuracy/state",         "",    "",               "measurement", true},
-        {"breath_voc",          "Breath VOC",           "homeassistant/sensor/sensorturtle/breath_voc/state",           "ppm", "",               "measurement", true},
-        {"co2_equivalent",      "CO2 Equivalent",       "homeassistant/sensor/sensorturtle/co2_equivalent/state",       "ppm", "carbon_dioxide", "measurement", true},
-        {"static_iaq_accuracy", "Static IAQ Accuracy",  "homeassistant/sensor/sensorturtle/static_iaq_accuracy/state",  "",    "",               "measurement", true},
-        {"comp_gas_value",      "Comp Gas Value",       "homeassistant/sensor/sensorturtle/comp_gas_value/state",       "",    "",               "measurement", true},
-        {"gas_percentage",      "Gas Percentage",       "homeassistant/sensor/sensorturtle/gas_percentage/state",       "%",   "",               "measurement", true},
+        {"temperature",         "Temperature",          "°C",  "temperature",    "measurement", true},
+        {"temperature_offset",  "Temperature (Offset)", "°C",  "temperature",    "measurement", true},
+        {"humidity",            "Humidity",             "%",   "humidity",       "measurement", true},
+        {"pressure",            "Air Pressure",         "hPa", "pressure",       "measurement", true},
+        {"gas",                 "Gas Resistance",       "Ω",   "",               "measurement", true},
+        {"iaq",                 "IAQ",                  "",    "",               "measurement", true},
+        {"iaq_accuracy",        "IAQ Accuracy",         "",    "",               "measurement", true},
+        {"breath_voc",          "Breath VOC",           "ppm", "",               "measurement", true},
+        {"co2_equivalent",      "CO2 Equivalent",       "ppm", "carbon_dioxide", "measurement", true},
+        {"static_iaq_accuracy", "Static IAQ Accuracy",  "",    "",               "measurement", true},
+        {"comp_gas_value",      "Comp Gas Value",       "",    "",               "measurement", true},
+        {"gas_percentage",      "Gas Percentage",       "%",   "",               "measurement", true},
         // MHZ19
-        {"co2",                 "CO2",                  "homeassistant/sensor/sensorturtle/co2/state",                  "ppm", "carbon_dioxide", "measurement", false},
-        {"co2_raw",             "CO2 Raw",              "homeassistant/sensor/sensorturtle/co2_raw/state",              "ppm", "carbon_dioxide", "measurement", false},
-        {"co2_accuracy",        "CO2 Accuracy",         "homeassistant/sensor/sensorturtle/co2_accuracy/state",         "",    "",               "measurement", false},
-        {"co2_limited",         "CO2 Limited",          "homeassistant/sensor/sensorturtle/co2_limited/state",          "ppm", "carbon_dioxide", "measurement", false},
-        {"co2_background",      "CO2 Background",       "homeassistant/sensor/sensorturtle/co2_background/state",       "ppm", "carbon_dioxide", "measurement", false},
-        {"co2_temp_adjustment", "CO2 Temp Adjustment",  "homeassistant/sensor/sensorturtle/co2_temp_adjustment/state",  "",    "",               "measurement", false},
-        {"co2_temperature",     "CO2 Temperature",      "homeassistant/sensor/sensorturtle/co2_temperature/state",      "°C",  "temperature",    "measurement", false},
+        {"co2",                 "CO2",                  "ppm", "carbon_dioxide", "measurement", false},
+        {"co2_raw",             "CO2 Raw",              "ppm", "carbon_dioxide", "measurement", false},
+        {"co2_accuracy",        "CO2 Accuracy",         "",    "",               "measurement", false},
+        {"co2_limited",         "CO2 Limited",          "ppm", "carbon_dioxide", "measurement", false},
+        {"co2_background",      "CO2 Background",       "ppm", "carbon_dioxide", "measurement", false},
+        {"co2_temp_adjustment", "CO2 Temp Adjustment",  "",    "",               "measurement", false},
+        {"co2_temperature",     "CO2 Temperature",      "°C",  "temperature",    "measurement", false},
     };
 
     for (auto& s : sensors)
     {
-        String configTopic = "homeassistant/sensor/sensorturtle/";
-        configTopic += s.uniqueId;
-        configTopic += "/config";
+        String configTopic = _topicBase + "/" + s.uniqueId + "/config";
+        String stateTopic  = _topicBase + "/" + s.uniqueId + "/state";
 
         String payload = "{";
-        payload += "\"unique_id\":\"sensorturtle_" + String(s.uniqueId) + "\",";
+        payload += "\"unique_id\":\"" + _deviceId + "_" + s.uniqueId + "\",";
         payload += "\"name\":\"" + String(s.name) + "\",";
-        payload += "\"state_topic\":\"" + String(s.stateTopic) + "\",";
+        payload += "\"state_topic\":\"" + stateTopic + "\",";
         if (strlen(s.unit) > 0) payload += "\"unit_of_measurement\":\"" + String(s.unit) + "\",";
         if (strlen(s.deviceClass) > 0) payload += "\"device_class\":\"" + String(s.deviceClass) + "\",";
         payload += "\"state_class\":\"" + String(s.stateClass) + "\",";
@@ -151,7 +159,7 @@ void MqttClientHandler::publishDiscovery()
         mqttClient.publish(configTopic.c_str(), 1, true, payload.c_str());
     }
 
-    Serial.println("[MQTT] Discovery published");
+    Serial.println("[MQTT] Discovery published for " + _deviceId);
 }
 
 void MqttClientHandler::publishData(const DataCO2 data_co2, const Bsec data_bme, const unsigned long currentSeconds)
@@ -163,27 +171,27 @@ void MqttClientHandler::publishData(const DataCO2 data_co2, const Bsec data_bme,
 		if (mqttClient.connected() == true)
 		{
 			// BME680
-			mqttClient.publish("homeassistant/sensor/sensorturtle/temperature/state",         1, true, String(data_bme.temperature).c_str());
-			mqttClient.publish("homeassistant/sensor/sensorturtle/temperature_offset/state",  1, true, String(data_bme.temperature + configHandler.getConfigSensor("tempOffset") / 10.0f).c_str());
-			mqttClient.publish("homeassistant/sensor/sensorturtle/humidity/state",            1, true, String(data_bme.humidity).c_str());
-			mqttClient.publish("homeassistant/sensor/sensorturtle/pressure/state",            1, true, String(data_bme.pressure / 100.0f).c_str());
-			mqttClient.publish("homeassistant/sensor/sensorturtle/gas/state",                 1, true, String(data_bme.gasResistance).c_str());
-			mqttClient.publish("homeassistant/sensor/sensorturtle/iaq/state",                 1, true, String(data_bme.iaq).c_str());
-			mqttClient.publish("homeassistant/sensor/sensorturtle/iaq_accuracy/state",        1, true, String(data_bme.iaqAccuracy).c_str());
-			mqttClient.publish("homeassistant/sensor/sensorturtle/breath_voc/state",          1, true, String(data_bme.breathVocEquivalent).c_str());
-			mqttClient.publish("homeassistant/sensor/sensorturtle/co2_equivalent/state",      1, true, String(data_bme.co2Equivalent).c_str());
-			mqttClient.publish("homeassistant/sensor/sensorturtle/static_iaq_accuracy/state", 1, true, String(data_bme.staticIaqAccuracy).c_str());
-			mqttClient.publish("homeassistant/sensor/sensorturtle/comp_gas_value/state",      1, true, String(data_bme.compGasValue).c_str());
-			mqttClient.publish("homeassistant/sensor/sensorturtle/gas_percentage/state",      1, true, String(data_bme.gasPercentage).c_str());
+			mqttClient.publish((_topicBase + "/temperature/state").c_str(),         1, true, String(data_bme.temperature).c_str());
+			mqttClient.publish((_topicBase + "/temperature_offset/state").c_str(),  1, true, String(data_bme.temperature + configHandler.getConfigSensor("tempOffset") / 10.0f).c_str());
+			mqttClient.publish((_topicBase + "/humidity/state").c_str(),            1, true, String(data_bme.humidity).c_str());
+			mqttClient.publish((_topicBase + "/pressure/state").c_str(),            1, true, String(data_bme.pressure / 100.0f).c_str());
+			mqttClient.publish((_topicBase + "/gas/state").c_str(),                 1, true, String(data_bme.gasResistance).c_str());
+			mqttClient.publish((_topicBase + "/iaq/state").c_str(),                 1, true, String(data_bme.iaq).c_str());
+			mqttClient.publish((_topicBase + "/iaq_accuracy/state").c_str(),        1, true, String(data_bme.iaqAccuracy).c_str());
+			mqttClient.publish((_topicBase + "/breath_voc/state").c_str(),          1, true, String(data_bme.breathVocEquivalent).c_str());
+			mqttClient.publish((_topicBase + "/co2_equivalent/state").c_str(),      1, true, String(data_bme.co2Equivalent).c_str());
+			mqttClient.publish((_topicBase + "/static_iaq_accuracy/state").c_str(), 1, true, String(data_bme.staticIaqAccuracy).c_str());
+			mqttClient.publish((_topicBase + "/comp_gas_value/state").c_str(),      1, true, String(data_bme.compGasValue).c_str());
+			mqttClient.publish((_topicBase + "/gas_percentage/state").c_str(),      1, true, String(data_bme.gasPercentage).c_str());
 
 			// MHZ19
-			mqttClient.publish("homeassistant/sensor/sensorturtle/co2/state",                 1, true, String(data_co2.getRegular()).c_str());
-			mqttClient.publish("homeassistant/sensor/sensorturtle/co2_raw/state",             1, true, String(data_co2.getRaw()).c_str());
-			mqttClient.publish("homeassistant/sensor/sensorturtle/co2_accuracy/state",        1, true, String(data_co2.getAccuracy()).c_str());
-			mqttClient.publish("homeassistant/sensor/sensorturtle/co2_limited/state",         1, true, String(data_co2.getLimited()).c_str());
-			mqttClient.publish("homeassistant/sensor/sensorturtle/co2_background/state",      1, true, String(data_co2.getBackground()).c_str());
-			mqttClient.publish("homeassistant/sensor/sensorturtle/co2_temp_adjustment/state", 1, true, String(data_co2.getTempAdjustment()).c_str());
-			mqttClient.publish("homeassistant/sensor/sensorturtle/co2_temperature/state",     1, true, String(data_co2.getTemperature()).c_str());
+			mqttClient.publish((_topicBase + "/co2/state").c_str(),                 1, true, String(data_co2.getRegular()).c_str());
+			mqttClient.publish((_topicBase + "/co2_raw/state").c_str(),             1, true, String(data_co2.getRaw()).c_str());
+			mqttClient.publish((_topicBase + "/co2_accuracy/state").c_str(),        1, true, String(data_co2.getAccuracy()).c_str());
+			mqttClient.publish((_topicBase + "/co2_limited/state").c_str(),         1, true, String(data_co2.getLimited()).c_str());
+			mqttClient.publish((_topicBase + "/co2_background/state").c_str(),      1, true, String(data_co2.getBackground()).c_str());
+			mqttClient.publish((_topicBase + "/co2_temp_adjustment/state").c_str(), 1, true, String(data_co2.getTempAdjustment()).c_str());
+			mqttClient.publish((_topicBase + "/co2_temperature/state").c_str(),     1, true, String(data_co2.getTemperature()).c_str());
 
 			#ifdef DEBUG
 						Serial.println("[MQTT] Send data");

--- a/src/MqttClientHandler.h
+++ b/src/MqttClientHandler.h
@@ -28,9 +28,9 @@ private:
     static void onMqttConnect(bool sessionPresent);
     static void onMqttDisconnect(AsyncMqttClientDisconnectReason reason);
     bool _isSetup = false;
-    String _mqttHost;
-    String _mqttUser;
-    String _mqttPass;
+    String _mqttHost;   // lifetime anchor – AsyncMqttClient holds a const char* pointer, not a copy
+    String _mqttUser;   // lifetime anchor – same reason
+    String _mqttPass;   // lifetime anchor – same reason
     static String _deviceId;        // deviceName aus NVS, normalisiert (lowercase, spaces→-)
     static String _topicBase;       // "homeassistant/sensor/<deviceId>"
     static unsigned long _lastRunSeconds;

--- a/src/MqttClientHandler.h
+++ b/src/MqttClientHandler.h
@@ -31,6 +31,8 @@ private:
     String _mqttHost;
     String _mqttUser;
     String _mqttPass;
+    static String _deviceId;        // deviceName aus NVS, normalisiert (lowercase, spaces→-)
+    static String _topicBase;       // "homeassistant/sensor/<deviceId>"
     static unsigned long _lastRunSeconds;
 };
 #endif // CO2_TURTLE_MQTTCLIENTHANDLER_H

--- a/src/WebServerHandler.cpp
+++ b/src/WebServerHandler.cpp
@@ -155,7 +155,7 @@ void WebServerHandler::handle_page_status(AsyncWebServerRequest *request)
 	}
 	String header_data = file.readString();
 	file.close();
-	header_data.replace("{{deviceName}}", DeviceName);
+	header_data.replace("{{deviceName}}", DEVICE_NAME);
 	header_data.replace("{{data_gas}}", String(bmedata.gasResistance));
 	header_data.replace("{{data_breahtvoc}}", String(bmedata.breathVocEquivalent));
 	header_data.replace("{{data_pressure}}", String(bmedata.pressure/100));
@@ -209,7 +209,7 @@ void WebServerHandler::handle_page_wlan(AsyncWebServerRequest *request)
 	String content = file.readString();
 	file.close();
 
-	content.replace("{{deviceName}}", DeviceName);
+	content.replace("{{deviceName}}", DEVICE_NAME);
     content.replace("{{ssid}}", ssid);
     request->send(200, "text/html", content);
 }
@@ -224,7 +224,7 @@ void WebServerHandler::handle_page_settings(AsyncWebServerRequest *request)
 	}
 	String content = file.readString();
 	file.close();
-	content.replace("{{deviceName}}", DeviceName);
+	content.replace("{{deviceName}}", DEVICE_NAME);
 
 	content.replace("{{intervalMHZ19}}", String(configHandler.getConfigInterval("intervalMHZ19")));
 	content.replace("{{intervalBME680}}", String(configHandler.getConfigInterval("intervalBME680")));
@@ -477,7 +477,7 @@ void WebServerHandler::handle_page_mqtt(AsyncWebServerRequest *request)
     String content = file.readString();
     file.close();
 
-    content.replace("{{deviceName}}", DeviceName);
+    content.replace("{{deviceName}}", DEVICE_NAME);
     content.replace("{{switchMQTT_checked}}", configHandler.getConfigSwitch("switchMQTT") ? "checked" : "");
     content.replace("{{mqttHOST}}", configHandler.getConfigDevice("mqttHOST"));
     content.replace("{{mqttPORT}}", configHandler.getConfigDevice("mqttPORT"));

--- a/src/WiFiHandler.cpp
+++ b/src/WiFiHandler.cpp
@@ -103,7 +103,7 @@ bool WiFiHandler::StatusCheck()
         Serial.println("[WIFI] Connection lost, reconnecting...");
         ReStart();
         bool reconnected = (WiFiClass::status() == WL_CONNECTED);
-        Serial.printf("[WIFI] Reconnect %s%s\n", reconnected ? "OK – IP: " : "FAILED", reconnected ? WiFi.localIP().toString().c_str() : "");
+    Serial.printf("[WIFI] Reconnect %s%s\n", reconnected ? "OK – IP: " : "FAILED", reconnected ? WiFi.localIP().toString().c_str() : "");
         connected = (WiFiClass::status() == WL_CONNECTED);
     }
     return connected;

--- a/src/WiFiHandler.cpp
+++ b/src/WiFiHandler.cpp
@@ -68,13 +68,13 @@ static void setupMDNS()
 void WiFiHandler::initWifi()
 {
     String hostname = configHandler.getConfigDevice("deviceName");
-    if (hostname == String(DeviceName))
+    if (hostname == String(DEVICE_NAME))
     {
         uint8_t mac[6];
         WiFi.macAddress(mac);
         char suffix[7];
         snprintf(suffix, sizeof(suffix), "%02x%02x%02x", mac[3], mac[4], mac[5]);
-        String prefix = String(DeviceName);
+        String prefix = String(DEVICE_NAME);
         prefix.replace(" ", "-");
         prefix.toLowerCase();
         hostname = prefix + "-" + suffix;

--- a/src/WiFiHandler.cpp
+++ b/src/WiFiHandler.cpp
@@ -68,8 +68,22 @@ static void setupMDNS()
 void WiFiHandler::initWifi()
 {
     String hostname = configHandler.getConfigDevice("deviceName");
+    if (hostname == String(DeviceName))
+    {
+        uint8_t mac[6];
+        WiFi.macAddress(mac);
+        char suffix[7];
+        snprintf(suffix, sizeof(suffix), "%02x%02x%02x", mac[3], mac[4], mac[5]);
+        String prefix = String(DeviceName);
+        prefix.replace(" ", "-");
+        prefix.toLowerCase();
+        hostname = prefix + "-" + suffix;
+        configHandler.setConfigDevice("deviceName", hostname);
+        Serial.println("[WIFI] Generated unique device name: " + hostname);
+    }
     hostname.replace(" ", "-");
     hostname.toLowerCase();
+    WiFi.mode(WIFI_STA);
     WiFi.setHostname(hostname.c_str());
     WiFi.setAutoReconnect(true);
     WiFi.persistent(true);
@@ -90,8 +104,12 @@ void WiFiHandler::initWifi()
 void WiFiHandler::ReStart()
 {
     loadWiFiCredentials();
+    String hostname = configHandler.getConfigDevice("deviceName");
+    hostname.replace(" ", "-");
+    hostname.toLowerCase();
     WiFi.disconnect(true);
     delay(100);
+    WiFi.setHostname(hostname.c_str());
     connectToWifi();
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -65,7 +65,8 @@ String localTime(const String &format)
 
 	String time = "";
 	char toutp[60];
-	setenv("TZ", TIMEZONE, 1); //  Now adjust the TZ.  Clock settings are adjusted to show the new local time
+	String tz = configHandler.getConfigDevice("timezone");
+	setenv("TZ", tz.c_str(), 1);
 	tzset();
 
 	if (!getLocalTime(&timeinfo))


### PR DESCRIPTION
What Changed
Unique Device Name on First Boot
When a device starts up for the first time and no custom name has been set, it now automatically generates a unique name by combining the configured default name (SensorTurtle) with the last three bytes of the device's WiFi MAC address (e.g. sensorturtle-579cc0). This name is saved to the device's persistent storage and used from that point on. The name can still be changed freely via the web interface.
MQTT Fully Dynamic
All MQTT communication — the client ID, the Home Assistant discovery messages, and the sensor data topics — was previously hardcoded to the name sensorturtle. This is now fully derived from the device name stored in persistent storage. Two devices with identical firmware will therefore register as completely separate entities in the MQTT broker and in Home Assistant, without any manual configuration step.
Timezone Configurable at Runtime
The timezone setting was previously fixed at compile time and could not be changed without rebuilding the firmware. It is now read from persistent storage on every boot, making it fully configurable through the web interface like all other settings.
LED Temperature Uses Configured Offset
The LED strip's temperature display was still using the compile-time temperature offset constant instead of the value configured in the web interface. This is now consistent with the E-Ink display, which already used the runtime value.
Cleanup

The switch_Webserver compile-time flag was removed, as the web server is always active and cannot be disabled.
A leftover global variable declaration for the old device name was removed from the shared configuration header.
Several #ifdef DEBUG guards were corrected to #if DEBUG for consistency with the rest of the codebase.


Impact

Existing devices that already have a custom name stored in persistent storage are not affected — the auto-generation only triggers when the stored name still matches the compiled-in default.
MQTT: After flashing, a device will publish under its newly generated name. Old retained topics in the broker (from the previous hardcoded name) must be cleared manually once.
No recompilation needed to deploy multiple devices — flash the same binary to all of them and each gets a unique identity automatically.