### PR TITLE
2612 iaq

### DIFF
--- a/doc/PROJECT_SUMMARY.md
+++ b/doc/PROJECT_SUMMARY.md
@@ -154,7 +154,9 @@ before the display hibernates.
 
 - BSEC config: `generic_33v_3s_4d` (3.3V, 3s sample rate, 4 days burn-in)
 - IAQ calibration persisted to EEPROM:
-  - First save: when IAQ accuracy reaches 3
+  - First save: when IAQ accuracy reaches **1** (previously 3 – threshold was unreachable
+    on new sensors, causing calibration state to never be written and progress to reset
+    on every reboot or I2C recovery)
   - Periodic saves: every 360 minutes
   - On startup: state restored from EEPROM if valid
 - Onboard LED (LED_BUILTIN) lights briefly during EEPROM writes
@@ -175,6 +177,8 @@ before the display hibernates.
 
 - Home Assistant MQTT discovery via `publishDiscovery()` on connect
 - Publishes all sensor values at `intervalMQTT`
+- BME680 values are only published when the sensor is actively delivering valid data;
+  no stale values are sent during I2C recovery
 - Optional user/password authentication (`mqttUSERen`)
 - Host, port, credentials fully configurable via web UI without recompiling
 - MQTT client-ID, discovery identifiers, and all state topics are derived from

--- a/src/BME680Handler.cpp
+++ b/src/BME680Handler.cpp
@@ -216,12 +216,12 @@ void BME680Handler::updateState(void)
     bool update = false;
     if (stateUpdateCounter == 0)
     {
-        /* First state update when IAQ accuracy is >= 3 */
-        if (bmeSensor.iaqAccuracy >= 3)
+        /* First state update when IAQ accuracy is >= 1 to preserve partial calibration */
+        if (bmeSensor.iaqAccuracy >= 1)
         {
             update = true;
             stateUpdateCounter++;
-            Serial.println("[BME680] First state update triggered");
+            Serial.println("[BME680] First state update triggered (accuracy=" + String(bmeSensor.iaqAccuracy) + ")");
         }
     }
     else

--- a/src/EPDHandler.cpp
+++ b/src/EPDHandler.cpp
@@ -107,16 +107,10 @@ void EPDHandler::printLayout(const DataCO2 &co2, const Bsec &bme_data, const Str
     display.drawInvertedBitmap(l.colL_icon, l.rowBot - 20, bitmap_hum,  24, 24, color_hum);
 
     // Left column values: Temperature (top), Humidity (bottom)
-    if (bmeOk)
-    {
-        printValue(buffer, l.colL_value, l.rowTop, color_temp, temperature);
-        display.drawInvertedBitmap(l.colL_icon, l.rowBot - 20, bitmap_hum,  24, 24, color_hum);
-    }
-
     // Left column values: Temperature (top), Humidity (bottom)
     if (bmeOk)
     {
-        printValue(buffer, l.colL_value, l.rowTop, color_temp, bme_data.temperature);
+        printValue(buffer, l.colL_value, l.rowTop, color_temp, temperature);
         printValue(buffer, l.colL_value, l.rowBot, color_hum,  bme_data.humidity);
     }
     else

--- a/src/MqttClientHandler.cpp
+++ b/src/MqttClientHandler.cpp
@@ -3,6 +3,7 @@
 #include "Credentials.h"
 #include <WiFi.h>
 #include "ConfigHandler.h"
+#include "BME680Handler.h"
 #include <AsyncMqttClient.h>
 unsigned long MqttClientHandler::_lastRunSeconds = 0;
 extern ConfigHandler &configHandler;
@@ -170,19 +171,23 @@ void MqttClientHandler::publishData(const DataCO2 data_co2, const Bsec data_bme,
 		connectToMqtt();
 		if (mqttClient.connected() == true)
 		{
-			// BME680
-			mqttClient.publish((_topicBase + "/temperature/state").c_str(),         1, true, String(data_bme.temperature).c_str());
-			mqttClient.publish((_topicBase + "/temperature_offset/state").c_str(),  1, true, String(data_bme.temperature + configHandler.getConfigSensor("tempOffset") / 10.0f).c_str());
-			mqttClient.publish((_topicBase + "/humidity/state").c_str(),            1, true, String(data_bme.humidity).c_str());
-			mqttClient.publish((_topicBase + "/pressure/state").c_str(),            1, true, String(data_bme.pressure / 100.0f).c_str());
-			mqttClient.publish((_topicBase + "/gas/state").c_str(),                 1, true, String(data_bme.gasResistance).c_str());
-			mqttClient.publish((_topicBase + "/iaq/state").c_str(),                 1, true, String(data_bme.iaq).c_str());
-			mqttClient.publish((_topicBase + "/iaq_accuracy/state").c_str(),        1, true, String(data_bme.iaqAccuracy).c_str());
-			mqttClient.publish((_topicBase + "/breath_voc/state").c_str(),          1, true, String(data_bme.breathVocEquivalent).c_str());
-			mqttClient.publish((_topicBase + "/co2_equivalent/state").c_str(),      1, true, String(data_bme.co2Equivalent).c_str());
-			mqttClient.publish((_topicBase + "/static_iaq_accuracy/state").c_str(), 1, true, String(data_bme.staticIaqAccuracy).c_str());
-			mqttClient.publish((_topicBase + "/comp_gas_value/state").c_str(),      1, true, String(data_bme.compGasValue).c_str());
-			mqttClient.publish((_topicBase + "/gas_percentage/state").c_str(),      1, true, String(data_bme.gasPercentage).c_str());
+            bool bmeOk = BME680Handler::getInstance().isSensorOk();
+			if (bmeOk)
+			{
+                // BME680
+                mqttClient.publish((_topicBase + "/temperature/state").c_str(),         1, true, String(data_bme.temperature).c_str());
+                mqttClient.publish((_topicBase + "/temperature_offset/state").c_str(),  1, true, String(data_bme.temperature + configHandler.getConfigSensor("tempOffset") / 10.0f).c_str());
+                mqttClient.publish((_topicBase + "/humidity/state").c_str(),            1, true, String(data_bme.humidity).c_str());
+                mqttClient.publish((_topicBase + "/pressure/state").c_str(),            1, true, String(data_bme.pressure / 100.0f).c_str());
+                mqttClient.publish((_topicBase + "/gas/state").c_str(),                 1, true, String(data_bme.gasResistance).c_str());
+                mqttClient.publish((_topicBase + "/iaq/state").c_str(),                 1, true, String(data_bme.iaq).c_str());
+                mqttClient.publish((_topicBase + "/iaq_accuracy/state").c_str(),        1, true, String(data_bme.iaqAccuracy).c_str());
+                mqttClient.publish((_topicBase + "/breath_voc/state").c_str(),          1, true, String(data_bme.breathVocEquivalent).c_str());
+                mqttClient.publish((_topicBase + "/co2_equivalent/state").c_str(),      1, true, String(data_bme.co2Equivalent).c_str());
+                mqttClient.publish((_topicBase + "/static_iaq_accuracy/state").c_str(), 1, true, String(data_bme.staticIaqAccuracy).c_str());
+                mqttClient.publish((_topicBase + "/comp_gas_value/state").c_str(),      1, true, String(data_bme.compGasValue).c_str());
+                mqttClient.publish((_topicBase + "/gas_percentage/state").c_str(),      1, true, String(data_bme.gasPercentage).c_str());
+            } // bmeOk
 
 			// MHZ19
 			mqttClient.publish((_topicBase + "/co2/state").c_str(),                 1, true, String(data_co2.getRegular()).c_str());


### PR DESCRIPTION
# Fix IAQ calibration stall, stale sensor data in MQTT, and temperature offset on display

## Background

After deployment, the BME680 air quality index (IAQ) accuracy level was stuck at 1 and
dropped back to 0 regularly. Investigation revealed three separate bugs working together:
the calibration state was never saved, which meant every reboot or sensor error reset the
learning process from scratch; the MQTT integration published outdated values during sensor
errors; and the temperature offset configured in the web interface had no visible effect on
the display.

---

## What Changed

### IAQ calibration now survives reboots and sensor errors

The BME680 sensor learns about its environment over time and stores this knowledge in memory.
To survive reboots, this learned state needs to be saved to the device's flash storage
periodically. The previous code only triggered this save once the sensor had reached
"full confidence" (accuracy level 3) — a level that requires days of uninterrupted operation
and is therefore never reached on a new sensor.

Because the state was never saved, every reboot and every I2C error recovery started the
learning process from zero. This created a loop: the sensor would slowly build up to
accuracy 1, hit an error, recover, and fall back to 0 — indefinitely.

The fix lowers the save threshold to accuracy level 1, which the sensor reaches within
minutes of startup. From that point on, the calibration state survives reboots and errors,
allowing the sensor to continue building toward higher accuracy levels over time.

### MQTT no longer publishes stale air quality data

While the BME680 sensor was recovering from an error, the firmware continued to publish
the last known measurements via MQTT — including IAQ, temperature, and humidity — as if
they were current readings. This caused misleading data in Home Assistant during error
and recovery windows.

BME680 sensor values are now only published when the sensor is confirmed to be actively
delivering valid data. MH-Z19B (CO2) readings are unaffected, as that sensor has its
own independent error state.

### Temperature offset now correctly shown on the display

The web interface allows configuring a temperature offset to compensate for the sensor's
self-heating. This offset was already used correctly for alert coloring on the display,
but the actual temperature number shown was the raw value without the offset applied —
due to a leftover duplicate rendering block that overwrote the corrected value at the
same screen position.

The duplicate block has been removed. The displayed temperature now matches the
offset-corrected value in all cases.

---

## Testing Notes

- After flashing, the BME680 state should be written to flash within a few minutes of
  startup (watch Serial output for `[BME680] First state update triggered`).
- After a reboot, the state should be loaded from flash (`[BME680] Reading BSEC state
  from EEPROM`) and accuracy should resume from the saved level rather than starting at 0.
- With MQTT enabled, BME680 topics should go silent during any sensor recovery window
  rather than repeating the last value.
- The temperature shown on the display should now reflect the configured offset.
