### PR TITLE
2612 device name oveall

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -18,19 +18,13 @@ lib_deps =
 	marvinroger/AsyncMqttClient@^0.9.0
 	boschsensortec/BSEC Software Library@^1.8.1492
 	esp32async/ESPAsyncWebServer@^3.7.7
+	esp32async/AsyncTCP@^3.4.10
 	fastled/FastLED@^3.7.0
 	wifwaf/MH-Z19@^1.5.4
 	zinggjm/GxEPD2@^1.5.7
 	plerup/EspSoftwareSerial@8.2.0
-lib_ignore =
-	me-no-dev/AsyncTCP
-	mathieucarbou/AsyncTCP
-	willmmiles/AsyncTCP
-	kubafilinger/AsyncTCP
-	tiotlab/AsyncTCP
-	zeed/AsyncTCP
 monitor_speed = 9600
-monitor_port = COM3
-upload_port = COM3
+monitor_port = COM6
+upload_port = COM6
 build_flags = -O2
 board_build.filesystem = littlefs

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -19,7 +19,7 @@
 #define interval_mqtt_in_Seconds 30
 
 #define SEALEVELPRESSURE_HPA 1015
-#define TEMPERATUR_OFFSET -3.5
+#define TEMPERATUR_OFFSET -5
 
 #define DEVICE_NAME "SensorTurtle"
 #define TIMEZONE "CET-1CEST,M3.5.0,M10.5.0/3"

--- a/src/WiFiHandler.cpp
+++ b/src/WiFiHandler.cpp
@@ -83,10 +83,11 @@ void WiFiHandler::initWifi()
     }
     hostname.replace(" ", "-");
     hostname.toLowerCase();
+    WiFi.persistent(false);
+    WiFi.disconnect(true);
     WiFi.mode(WIFI_STA);
     WiFi.setHostname(hostname.c_str());
     WiFi.setAutoReconnect(true);
-    WiFi.persistent(true);
 
     loadWiFiCredentials();
 


### PR DESCRIPTION
## Summary
Each SensorTurtle now carries a consistent, MAC-based identity visible
in every layer of the stack — from the router's DHCP table to the
e-ink display and InfluxDB.

## Changes

**WiFiHandler.cpp**
- Disabled WiFi.persistent() and added WiFi.disconnect(true) before
  mode switch so the ESP32 IDF no longer restores the cached default
  hostname (esp32-XXXXXX) on boot
- setHostname() now reliably applies the MAC-suffixed deviceName
  before WiFi.begin()

**EPDHandler.cpp**
- Replaced static DEVICE_NAME constant with runtime deviceName from
  ConfigHandler, which already contains the MAC suffix
  (e.g. sensor-turtle-09C7E0)

**platformio.ini**
- Pinned AsyncTCP explicitly to esp32async/AsyncTCP@^3.4.10
- Removed lib_ignore workaround — no longer needed with explicit owner