### PR TITLE
feat(epd): show full device name including MAC suffix on e-ink display

### DIFF
--- a/src/EPDHandler.cpp
+++ b/src/EPDHandler.cpp
@@ -165,7 +165,13 @@ void EPDHandler::printLayout(const DataCO2 &co2, const Bsec &bme_data, const Str
     display.print(footerStr(epd_date + " " + epd_time));
     display.drawInvertedBitmap(l.footerTurtleX, l.footerTurtleY, bitmap_turtle, 18, 18, GxEPD_RED);
     display.setCursor(l.footerNameX, l.footerNameY);
-    display.print(footerStr(String(DEVICE_NAME)));
+
+    uint8_t mac[6];
+    WiFi.macAddress(mac);
+    char macSuffix[7];
+    snprintf(macSuffix, sizeof(macSuffix), "%02X%02X%02X", mac[3], mac[4], mac[5]);
+    display.print(footerStr(configHandler.getConfigDevice("deviceName")));
+    
     display.display(false);
     display.hibernate();
     display.end();


### PR DESCRIPTION
Replaced the static DEVICE_NAME constant with the runtime deviceName from ConfigHandler, which already includes the MAC-based suffix (e.g. sensor-turtle-09C7E0).
Reuses the MAC address already available via WiFi.h.