### PR TITLE
feat(web): split settings into dedicated pages, add MH-Z19 variant UI

### DIFF
--- a/data/static/epd.htm
+++ b/data/static/epd.htm
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>{{deviceName}} - Display Settings</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+<div class="container">
+<div class="nav">
+<a href="/index" class="button">Back to Index</a>
+</div>
+<div class="content">
+<h1>Display Settings</h1>
+
+<form id="epdSettingsForm">
+<h2>Display Switch</h2>
+<div class="form-row">
+<label for="switchEPD">E-Ink Display enabled</label>
+<input type="checkbox" id="switchEPD" name="switchEPD" {{switchEPD_checked}}>
+</div>
+
+<h2>Orientation</h2>
+<div class="form-row">
+<label for="switchEPDorientation">EPD Orientation</label>
+<select id="switchEPDorientation" name="switchEPDorientation">
+  <option value="0" {{epdOrientation_0}}>Vertical 90° (cable up)</option>
+  <option value="1" {{epdOrientation_1}}>Vertical 270° (cable down)</option>
+  <option value="2" {{epdOrientation_2}}>Horizontal 90° (cable left)</option>
+  <option value="3" {{epdOrientation_3}}>Horizontal 270° (cable right)</option>
+</select>
+</div>
+
+<h2>Interval</h2>
+<div class="form-row">
+<label for="intervalEPD">Refresh Interval (s)</label>
+<input type="number" id="intervalEPD" name="intervalEPD" value="{{intervalEPD}}" min="16">
+</div>
+
+<div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-top:20px;">
+<button type="submit" class="btn" style="margin-top:0;">Save Display Settings</button>
+<button type="button" class="btn" id="btnEPDrefresh" style="margin-top:0;">Refresh Display Now</button>
+</div>
+<div class="form-feedback" id="feedbackEPD"></div>
+</form>
+
+</div>
+</div>
+<div class="footer">&copy; 2025 SensorTurtle</div>
+<script>
+document.addEventListener("DOMContentLoaded", function() {
+  function showFeedback(id, ok) {
+    var el = document.getElementById(id);
+    el.textContent = ok ? "Saved successfully!" : "Error saving settings.";
+    el.className = "form-feedback " + (ok ? "success" : "error");
+    setTimeout(function() { el.textContent = ""; el.className = "form-feedback"; }, 3000);
+  }
+
+  document.getElementById("epdSettingsForm").addEventListener("submit", function(e) {
+    e.preventDefault();
+    var cb = document.getElementById("switchEPD");
+    var sel = document.getElementById("switchEPDorientation");
+    var iv = document.getElementById("intervalEPD");
+    var params = "switchEPD=" + (cb.checked ? 1 : 0)
+               + "&switchEPDorientation=" + encodeURIComponent(sel.value)
+               + "&intervalEPD=" + encodeURIComponent(iv.value);
+    fetch("/submitEPDsettings", { method: "POST", headers: { "Content-Type": "application/x-www-form-urlencoded" }, body: params })
+      .then(function(r) { showFeedback("feedbackEPD", r.ok); })
+      .catch(function() { showFeedback("feedbackEPD", false); });
+  });
+
+  document.getElementById("btnEPDrefresh").addEventListener("click", function() {
+    fetch("/api/epd/refresh", { method: "POST" })
+      .then(function(r) { showFeedback("feedbackEPD", r.ok); });
+  });
+});
+</script>
+</body>
+</html>

--- a/data/static/index.htm
+++ b/data/static/index.htm
@@ -17,12 +17,14 @@
         <div class="nav">
             <a href="/sensorsettings" class="button">Sensor Settings</a>
             <a href="/WLAN" class="button">WLAN Settings</a>
+            <a href="/led" class="button">LED Settings</a>
+            <a href="/epd" class="button">Display Settings</a>
             <a href="/mqtt" class="button">MQTT Settings</a>
         </div>
     </div>
     <div class="content">
         <div id="warningBanner" style="display:none;background:#fff3cd;border:1px solid #ffc107;border-radius:5px;padding:15px;margin-top:20px;">
-            <strong>⚠ BME680 sensor error</strong>
+            <strong>&#9888; BME680 sensor error</strong>
             <span id="warningText"></span>
             <div style="margin-top:10px;">
                 <form action="/restart" method="POST" id="restartForm">

--- a/data/static/led.htm
+++ b/data/static/led.htm
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>{{deviceName}} - LED Settings</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+<div class="container">
+<div class="nav">
+<a href="/index" class="button">Back to Index</a>
+</div>
+<div class="content">
+<h1>LED Settings</h1>
+
+<form id="ledSettingsForm">
+<h2>LED Switch</h2>
+<div class="form-row">
+<label for="switchLED">LED Strip enabled</label>
+<input type="checkbox" id="switchLED" name="switchLED" {{switchLED_checked}}>
+</div>
+
+<h2>Brightness</h2>
+<div class="form-row">
+<label for="ledBrightness">Brightness: <span id="brightnessValue">{{LEDbrightness}}</span></label>
+<input type="range" id="ledBrightness" name="LEDbrightness" min="2" max="255" value="{{LEDbrightness}}">
+</div>
+
+<h2>Interval</h2>
+<div class="form-row">
+<label for="intervalLED">LED Update Interval (s)</label>
+<input type="number" id="intervalLED" name="intervalLED" value="{{intervalLED}}" min="1">
+</div>
+
+<button type="submit" class="btn">Save LED Settings</button>
+<div class="form-feedback" id="feedbackLED"></div>
+</form>
+
+</div>
+</div>
+<div class="footer">&copy; 2025 SensorTurtle</div>
+<script>
+document.addEventListener("DOMContentLoaded", function() {
+  function showFeedback(id, ok) {
+    var el = document.getElementById(id);
+    el.textContent = ok ? "Saved successfully!" : "Error saving settings.";
+    el.className = "form-feedback " + (ok ? "success" : "error");
+    setTimeout(function() { el.textContent = ""; el.className = "form-feedback"; }, 3000);
+  }
+
+  var slider = document.getElementById("ledBrightness");
+  slider.addEventListener("input", function() {
+    document.getElementById("brightnessValue").textContent = slider.value;
+  });
+
+  document.getElementById("ledSettingsForm").addEventListener("submit", function(e) {
+    e.preventDefault();
+    var cb = document.getElementById("switchLED");
+    var params = "switchLED=" + (cb.checked ? 1 : 0)
+               + "&LEDbrightness=" + encodeURIComponent(slider.value)
+               + "&intervalLED=" + encodeURIComponent(document.getElementById("intervalLED").value);
+    fetch("/submitLEDsettings", { method: "POST", headers: { "Content-Type": "application/x-www-form-urlencoded" }, body: params })
+      .then(function(r) { showFeedback("feedbackLED", r.ok); })
+      .catch(function() { showFeedback("feedbackLED", false); });
+  });
+});
+</script>
+</body>
+</html>

--- a/data/static/settings.htm
+++ b/data/static/settings.htm
@@ -14,38 +14,8 @@
 <div class="content">
 <h1>Sensor Settings</h1>
 
-<h2>Module Switch</h2>
-<form action="/submitmodulswitch" method="POST" id="moduleSwitchForm">
-<div class="form-row">
-<label for="switchWIFI">WiFi Check</label>
-<input type="checkbox" id="switchWIFI" name="switchWIFI" {{switchWIFI_checked}}>
-</div>
-<div class="form-row">
-    <label for="switchEPD">EPD Display</label>
-    <input type="checkbox" id="switchEPD" name="switchEPD" {{switchEPD_checked}}>
-</div>
-<div class="form-row">
-    <label for="switchEPDorientation">EPD Orientation</label>
-    <select id="switchEPDorientation" name="switchEPDorientation">
-        <option value="0" {{epdOrientation_0}}>Vertical 90°</option>
-        <option value="1" {{epdOrientation_1}}>Vertical 270°</option>
-        <option value="2" {{epdOrientation_2}}>Horizontal 90°</option>
-        <option value="3" {{epdOrientation_3}}>Horizontal 270°</option>
-    </select>
-</div>
-<div class="form-row">
-    <label for="switchLED">LED</label>
-    <input type="checkbox" id="switchLED" name="switchLED" {{switchLED_checked}}>
-</div>
-<div style="display:flex;gap:8px;align-items:center;">
-    <button type="submit" class="btn">Save Settings</button>
-    <button type="button" class="btn" id="btnEPDrefresh">Refresh Display</button>
-</div>
-<div class="form-feedback" id="feedbackSwitch"></div>
-</form>
-
 <h2>Sensor Configuration</h2>
-<form action="/submitSensorConfig" method="POST" id="sensorConfigForm">
+<form id="sensorConfigForm">
 <div class="form-row">
 <label for="sealevelpressure">Sea Level Pressure (hPa)</label>
 <input type="number" id="sealevelpressure" name="SEALEVELPRESSURE_HPA" value="{{SEALEVELPRESSURE_HPA}}" step="1" min="900" max="1100">
@@ -58,10 +28,27 @@
 <div class="form-feedback" id="feedbackSensor"></div>
 </form>
 
-<h2>Module Time Interval</h2>
-<form action="/submitmodulinterval" method="POST" id="moduleIntervalForm">
+<h2>MH-Z19 Sensor</h2>
+<p style="font-size:14px;color:#555;margin-bottom:12px;">
+  Detected variant: <strong>{{mhz19DetectedVariant}}</strong>
+</p>
+<form id="sensorVariantForm">
 <div class="form-row">
-<label for="intervalMHZ19">MHZ19 Interval (s)</label>
+<label for="sensorMHZ19variant">Sensor Variant</label>
+<select id="sensorMHZ19variant" name="sensorMHZ19variant">
+  <option value="0" {{sensorMHZ19variant_0}}>Auto-Detect</option>
+  <option value="1" {{sensorMHZ19variant_1}}>MH-Z19 (original)</option>
+  <option value="2" {{sensorMHZ19variant_2}}>MH-Z19B / MH-Z19C</option>
+</select>
+</div>
+<button type="submit" class="btn">Save Variant</button>
+<div class="form-feedback" id="feedbackVariant"></div>
+</form>
+
+<h2>Sensor Intervals</h2>
+<form id="moduleIntervalForm">
+<div class="form-row">
+<label for="intervalMHZ19">MH-Z19 Interval (s)</label>
 <input type="number" id="intervalMHZ19" name="intervalMHZ19" value="{{intervalMHZ19}}" min="1">
 </div>
 <div class="form-row">
@@ -69,49 +56,28 @@
 <input type="number" id="intervalBME680" name="intervalBME680" value="{{intervalBME680}}" min="3">
 </div>
 <div class="form-row">
-<label for="intervalWiFi">WiFi Check Interval (s)</label>
-<input type="number" id="intervalWiFi" name="intervalWiFi" value="{{intervalWiFi}}" min="1">
-</div>
-<div class="form-row">
 <label for="intervalPRINT">RAM Printout Interval (s)</label>
 <input type="number" id="intervalPRINT" name="intervalPRINT" value="{{intervalPRINT}}" min="1">
-</div>
-<div class="form-row">
-<label for="intervalEPD">EPD Refresh Interval (s)</label>
-<input type="number" id="intervalEPD" name="intervalEPD" value="{{intervalEPD}}" min="16">
-</div>
-<div class="form-row">
-<label for="intervalLED">LED Update Interval (s)</label>
-<input type="number" id="intervalLED" name="intervalLED" value="{{intervalLED}}" min="1">
 </div>
 <div class="form-row">
 <label for="intervalMQTT">MQTT Interval (s)</label>
 <input type="number" id="intervalMQTT" name="intervalMQTT" value="{{intervalMQTT}}" min="1">
 </div>
-<button type="submit" class="btn">Save Interval</button>
+<button type="submit" class="btn">Save Intervals</button>
 <div class="form-feedback" id="feedbackInterval"></div>
 </form>
 
-<h2>LED Brightness</h2>
-<form id="ledconfigForm">
-<div class="form-row">
-<label for="ledBrightness">Brightness: <span id="brightnessValue">{{LEDbrightness}}</span></label>
-<input type="range" id="ledBrightness" name="LEDbrightness" min="2" max="255" value="{{LEDbrightness}}">
-</div>
-<button type="submit" class="btn">Save Brightness</button>
-<div class="form-feedback" id="feedbackBrightness"></div>
+<h2>Calibration</h2>
+<form id="calibrateForm">
+<p style="font-size:13px;color:#555;margin-bottom:8px;">Place sensor in fresh outdoor air (~400 ppm) before calibrating.</p>
+<button type="submit" class="btn">Calibrate MH-Z19</button>
 </form>
 
-<h2>Sensor Option</h2>
-<form action="/calibrateMHZ19" method="POST" id="calibrateForm">
-<button type="submit" class="btn">Calibrate MHZ19</button>
-</form>
-
-<h2>ESP32 Option</h2>
-<form action="/restart" method="POST">
+<h2>Device Options</h2>
+<form action="/restart" method="POST" id="restartForm">
 <button type="submit" class="btn">Restart ESP32</button>
 </form>
-<form action="/restoredefaultconfiguration" method="POST">
+<form action="/restoredefaultconfiguration" method="POST" style="margin-top:10px;">
 <button type="submit" class="btn">Load Defaults</button>
 </form>
 
@@ -119,61 +85,63 @@
 </div>
 <div class="footer">&copy; 2025 SensorTurtle</div>
 <script>
-document.getElementById("btnEPDrefresh").addEventListener("click", function() {
-    fetch("/api/epd/refresh", { method: "POST" })
-        .then(function(r) { showFeedback("feedbackSwitch", r.ok); });
-});
+document.addEventListener("DOMContentLoaded", function() {
+  function showFeedback(id, ok) {
+    var el = document.getElementById(id);
+    el.textContent = ok ? "Saved successfully!" : "Error saving settings.";
+    el.className = "form-feedback " + (ok ? "success" : "error");
+    setTimeout(function() { el.textContent = ""; el.className = "form-feedback"; }, 3000);
+  }
+  function submitForm(url, params, id) {
+    fetch(url, { method: "POST", headers: { "Content-Type": "application/x-www-form-urlencoded" }, body: params })
+      .then(function(r) { showFeedback(id, r.ok); })
+      .catch(function() { showFeedback(id, false); });
+  }
 
-document.addEventListener("DOMContentLoaded",function(){
-function showFeedback(id,ok){
-var el=document.getElementById(id);
-el.textContent=ok?"Saved successfully!":"Error saving settings.";
-el.className="form-feedback "+(ok?"success":"error");
-setTimeout(function(){el.textContent="";el.className="form-feedback";},3000);
-}
-function submitForm(url,params,id){
-fetch(url,{method:"POST",headers:{"Content-Type":"application/x-www-form-urlencoded"},body:params})
-.then(function(r){showFeedback(id,r.ok);})
-.catch(function(){showFeedback(id,false);});
-}
-var switchForm=document.getElementById("moduleSwitchForm");
-switchForm.addEventListener("submit",function(e){
-e.preventDefault();
-var params=Array.from(switchForm.querySelectorAll("input[type=checkbox],select")).map(function(c){
-return encodeURIComponent(c.name)+"="+(c.tagName==="SELECT"?encodeURIComponent(c.value):(c.checked?1:0));
-}).join("&");
-submitForm("/submitmodulswitch",params,"feedbackSwitch");
-});
-var intervalForm=document.getElementById("moduleIntervalForm");
-intervalForm.addEventListener("submit",function(e){
-e.preventDefault();
-var params=Array.from(intervalForm.querySelectorAll("input[type=number]")).map(function(i){
-return encodeURIComponent(i.name)+"="+encodeURIComponent(i.value);
-}).join("&");
-submitForm("/submitmodulinterval?"+params,"","feedbackInterval");
-});
-var slider=document.getElementById("ledBrightness");
-slider.addEventListener("input",function(){document.getElementById("brightnessValue").textContent=slider.value;});
-document.getElementById("ledconfigForm").addEventListener("submit",function(e){
-e.preventDefault();
-submitForm("/submitLEDConfig","LEDbrightness="+encodeURIComponent(slider.value),"feedbackBrightness");
-});
-document.getElementById("calibrateForm").addEventListener("submit",function(e){
-e.preventDefault();
-if(confirm("Calibrate MHZ19? Make sure sensor is in fresh air (400 ppm).")){
-fetch("/calibrateMHZ19",{method:"POST"}).then(function(r){
-alert(r.ok?"Calibration started!":"Failed to start calibration.");
-}).catch(function(){alert("An error occurred.");});
-}
-});
-var sensorForm=document.getElementById("sensorConfigForm");
-sensorForm.addEventListener("submit",function(e){
-e.preventDefault();
-var params=Array.from(sensorForm.querySelectorAll("input[type=number]")).map(function(i){
-return encodeURIComponent(i.name)+"="+encodeURIComponent(i.value);
-}).join("&");
-submitForm("/submitSensorConfig",params,"feedbackSensor");
-});
+  // Sensor config form
+  document.getElementById("sensorConfigForm").addEventListener("submit", function(e) {
+    e.preventDefault();
+    var params = Array.from(this.querySelectorAll("input[type=number]")).map(function(i) {
+      return encodeURIComponent(i.name) + "=" + encodeURIComponent(i.value);
+    }).join("&");
+    submitForm("/submitSensorConfig", params, "feedbackSensor");
+  });
+
+  // Sensor variant form
+  document.getElementById("sensorVariantForm").addEventListener("submit", function(e) {
+    e.preventDefault();
+    var sel = document.getElementById("sensorMHZ19variant");
+    submitForm("/submitSensorConfig", "sensorMHZ19variant=" + encodeURIComponent(sel.value), "feedbackVariant");
+  });
+
+  // Intervals form
+  document.getElementById("moduleIntervalForm").addEventListener("submit", function(e) {
+    e.preventDefault();
+    var params = Array.from(this.querySelectorAll("input[type=number]")).map(function(i) {
+      return encodeURIComponent(i.name) + "=" + encodeURIComponent(i.value);
+    }).join("&");
+    submitForm("/submitmodulinterval", params, "feedbackInterval");
+  });
+
+  // Calibrate form
+  document.getElementById("calibrateForm").addEventListener("submit", function(e) {
+    e.preventDefault();
+    if (confirm("Calibrate MH-Z19? Make sure sensor is in fresh air (400 ppm).")) {
+      fetch("/calibrateMHZ19", { method: "POST" })
+        .then(function(r) { alert(r.ok ? "Calibration started!" : "Failed to start calibration."); })
+        .catch(function() { alert("An error occurred."); });
+    }
+  });
+
+  // Restart form
+  document.getElementById("restartForm").addEventListener("submit", function(e) {
+    e.preventDefault();
+    if (confirm("Restart ESP32?")) {
+      fetch("/restart", { method: "POST" }).then(function() {
+        setTimeout(function() { window.location.href = "/index"; }, 6000);
+      });
+    }
+  });
 });
 </script>
 </body>

--- a/data/static/wlan.htm
+++ b/data/static/wlan.htm
@@ -13,7 +13,9 @@
 </div>
 <div class="content">
 <h1>WLAN Settings</h1>
-<form action="/submitWLANcredentials" method="POST" id="wlanForm">
+
+<h2>WiFi Credentials</h2>
+<form id="wlanForm">
 <div class="form-row">
 <label for="wlanSSID">SSID</label>
 <input type="text" id="wlanSSID" name="wlanSSID" value="{{ssid}}">
@@ -28,13 +30,62 @@
 </svg>
 </button>
 </div>
-<button type="submit" class="btn">Submit</button>
+<p style="font-size:13px;color:#555;margin-top:4px;">The device will restart and reconnect after saving.</p>
+<button type="submit" class="btn">Save &amp; Restart</button>
+<div class="form-feedback" id="feedbackCredentials"></div>
 </form>
+
+<h2>WiFi Settings</h2>
+<form id="wlanSettingsForm">
+<div class="form-row">
+<label for="switchWIFI">WiFi Check enabled</label>
+<input type="checkbox" id="switchWIFI" name="switchWIFI" {{switchWIFI_checked}}>
+</div>
+<div class="form-row">
+<label for="intervalWiFi">WiFi Check Interval (s)</label>
+<input type="number" id="intervalWiFi" name="intervalWiFi" value="{{intervalWiFi}}" min="10">
+</div>
+<button type="submit" class="btn">Save Settings</button>
+<div class="form-feedback" id="feedbackWLAN"></div>
+</form>
+
 </div>
 </div>
 <div class="footer">&copy; 2025 SensorTurtle</div>
 <script>
-function togglePassword(show){document.getElementById('wlanPASSWORD').type=show?'text':'password';}
+function togglePassword(show) { document.getElementById('wlanPASSWORD').type = show ? 'text' : 'password'; }
+
+document.addEventListener("DOMContentLoaded", function() {
+  function showFeedback(id, ok) {
+    var el = document.getElementById(id);
+    el.textContent = ok ? "Saved successfully!" : "Error saving settings.";
+    el.className = "form-feedback " + (ok ? "success" : "error");
+    setTimeout(function() { el.textContent = ""; el.className = "form-feedback"; }, 3000);
+  }
+
+  // Credentials form — full page POST (triggers restart)
+  document.getElementById("wlanForm").addEventListener("submit", function(e) {
+    e.preventDefault();
+    var params = "wlanSSID=" + encodeURIComponent(document.getElementById("wlanSSID").value)
+               + "&wlanPASSWORD=" + encodeURIComponent(document.getElementById("wlanPASSWORD").value);
+    fetch("/submitWLANcredentials", { method: "POST", headers: { "Content-Type": "application/x-www-form-urlencoded" }, body: params })
+      .then(function(r) { return r.text(); })
+      .then(function(html) { document.open(); document.write(html); document.close(); })
+      .catch(function() { showFeedback("feedbackCredentials", false); });
+  });
+
+  // WiFi settings form (switch + interval, no restart)
+  document.getElementById("wlanSettingsForm").addEventListener("submit", function(e) {
+    e.preventDefault();
+    var cb = document.getElementById("switchWIFI");
+    var iv = document.getElementById("intervalWiFi");
+    var params = "switchWIFI=" + (cb.checked ? 1 : 0)
+               + "&intervalWiFi=" + encodeURIComponent(iv.value);
+    fetch("/submitWLANsettings", { method: "POST", headers: { "Content-Type": "application/x-www-form-urlencoded" }, body: params })
+      .then(function(r) { showFeedback("feedbackWLAN", r.ok); })
+      .catch(function() { showFeedback("feedbackWLAN", false); });
+  });
+});
 </script>
 </body>
 </html>

--- a/src/WebServerHandler.cpp
+++ b/src/WebServerHandler.cpp
@@ -21,6 +21,8 @@ void WebServerHandler::start()
 	server.on("/static/status.htm", HTTP_GET, [](AsyncWebServerRequest *request) {request->send(LittleFS, "/static/status.htm", "text/html");});
 	server.on("/static/settings.htm", HTTP_GET, [](AsyncWebServerRequest *request) {request->send(LittleFS, "/static/settings.htm", "text/html");});
 	server.on("/static/wlan.htm", HTTP_GET, [](AsyncWebServerRequest *request) {request->send(LittleFS, "/static/wlan.htm", "text/html");});
+	server.on("/static/led.htm", HTTP_GET, [](AsyncWebServerRequest *request) {request->send(LittleFS, "/static/led.htm", "text/html");});
+	server.on("/static/epd.htm", HTTP_GET, [](AsyncWebServerRequest *request) {request->send(LittleFS, "/static/epd.htm", "text/html");});
 	server.on("/static/template.htm", HTTP_GET, [](AsyncWebServerRequest *request) {request->send(LittleFS, "/static/template.htm", "text/html");});
 
 	// webserver linking
@@ -30,10 +32,13 @@ void WebServerHandler::start()
 	server.on("/status", HTTP_GET, [this](AsyncWebServerRequest *request) {handle_page_status(request); });
 	server.on("/sensorsettings", HTTP_GET, [this](AsyncWebServerRequest *request) {handle_page_settings(request); });
 	server.on("/WLAN", HTTP_GET, [this](AsyncWebServerRequest *request) {handle_page_wlan(request); });
+	server.on("/led", HTTP_GET, [this](AsyncWebServerRequest *request) {handle_page_led(request); });
+	server.on("/epd", HTTP_GET, [this](AsyncWebServerRequest *request) {handle_page_epd(request); });
 	server.on("/submitWLANcredentials", HTTP_POST, [this](AsyncWebServerRequest *request) {handle_submit_WLANcredentials(request); });
+	server.on("/submitWLANsettings", HTTP_POST, [this](AsyncWebServerRequest *request) {handle_submit_wlansettings(request); });
 	server.on("/submitmodulinterval", HTTP_POST, [this](AsyncWebServerRequest *request) {handle_submit_modulinterval(request); });
-	server.on("/submitmodulswitch", HTTP_POST, [this](AsyncWebServerRequest *request) {handle_submit_modulswitch(request); });
-	server.on("/submitLEDConfig", HTTP_POST, [this](AsyncWebServerRequest *request) {handle_submit_ledconfig(request); });
+	server.on("/submitLEDsettings", HTTP_POST, [this](AsyncWebServerRequest *request) {handle_submit_ledsettings(request); });
+	server.on("/submitEPDsettings", HTTP_POST, [this](AsyncWebServerRequest *request) {handle_submit_epdsettings(request); });
 	server.on("/submitSensorConfig", HTTP_POST, [this](AsyncWebServerRequest *request) { handle_submit_sensorconfig(request); });
 	server.on("/restoredefaultconfiguration", HTTP_POST, [this](AsyncWebServerRequest *request) {handle_option_restoreDefaultConfiguration(request); });
 	server.on("/restart", HTTP_POST, [this](AsyncWebServerRequest *request) {handle_option_restart(request); });
@@ -210,8 +215,10 @@ void WebServerHandler::handle_page_wlan(AsyncWebServerRequest *request)
 	file.close();
 
 	content.replace("{{deviceName}}", DEVICE_NAME);
-    content.replace("{{ssid}}", ssid);
-    request->send(200, "text/html", content);
+	content.replace("{{ssid}}", ssid);
+	content.replace("{{switchWIFI_checked}}", configHandler.getConfigSwitch("switchWIFI") ? "checked" : "");
+	content.replace("{{intervalWiFi}}", String(configHandler.getConfigInterval("intervalWiFi")));
+	request->send(200, "text/html", content);
 }
 
 void WebServerHandler::handle_page_settings(AsyncWebServerRequest *request)
@@ -228,25 +235,17 @@ void WebServerHandler::handle_page_settings(AsyncWebServerRequest *request)
 
 	content.replace("{{intervalMHZ19}}", String(configHandler.getConfigInterval("intervalMHZ19")));
 	content.replace("{{intervalBME680}}", String(configHandler.getConfigInterval("intervalBME680")));
-	content.replace("{{intervalWiFi}}", String(configHandler.getConfigInterval("intervalWiFi")));
 	content.replace("{{intervalPRINT}}", String(configHandler.getConfigInterval("intervalPRINT")));
-	content.replace("{{intervalEPD}}", String(configHandler.getConfigInterval("intervalEPD")));
-	content.replace("{{intervalLED}}", String(configHandler.getConfigInterval("intervalLED")));
 	content.replace("{{intervalMQTT}}", String(configHandler.getConfigInterval("intervalMQTT")));
 
-	content.replace("{{switchWIFI_checked}}", configHandler.getConfigSwitch("switchWIFI") ? "checked" : "");
-	content.replace("{{switchEPD_checked}}", configHandler.getConfigSwitch("switchEPD") ? "checked" : "");
-	content.replace("{{switchLED_checked}}", configHandler.getConfigSwitch("switchLED") ? "checked" : "");
-
-	int epdOri = configHandler.getConfigSwitch("switchEPDorientation");
-	content.replace("{{epdOrientation_0}}", epdOri == 0 ? "selected" : "");
-	content.replace("{{epdOrientation_1}}", epdOri == 1 ? "selected" : "");
-	content.replace("{{epdOrientation_2}}", epdOri == 2 ? "selected" : "");
-	content.replace("{{epdOrientation_3}}", epdOri == 3 ? "selected" : "");
-
-	content.replace("{{LEDbrightness}}", String(configHandler.getConfigLED("LEDbrightness")));
 	content.replace("{{SEALEVELPRESSURE_HPA}}", String(configHandler.getConfigSensor("pressure")));
 	content.replace("{{TEMPERATUR_OFFSET}}", String(configHandler.getConfigSensor("tempOffset") / 10.0f));
+
+	content.replace("{{mhz19DetectedVariant}}", MHZ19Handler::getInstance().getSensorVariantName());
+	int mhzVariant = configHandler.getConfigSensor("sensorMHZ19variant");
+	content.replace("{{sensorMHZ19variant_0}}", mhzVariant == 0 ? "selected" : "");
+	content.replace("{{sensorMHZ19variant_1}}", mhzVariant == 1 ? "selected" : "");
+	content.replace("{{sensorMHZ19variant_2}}", mhzVariant == 2 ? "selected" : "");
 
 	request->send(200, "text/html; charset=utf-8", content);
 }
@@ -287,114 +286,91 @@ void WebServerHandler::handle_submit_WLANcredentials(AsyncWebServerRequest *requ
 void WebServerHandler::handle_submit_modulinterval(AsyncWebServerRequest *request)
 {
 	if (request->hasParam("intervalMHZ19"))
-	{
 		configHandler.setConfigInterval("intervalMHZ19", request->getParam("intervalMHZ19")->value().toInt());
-	}
-	else
-	{
-		Serial.printf("[WebServer] intervalMHZ19 missing, using default: %ds\n", interval_MHZ19_in_Seconds);
-		configHandler.setConfigInterval("intervalMHZ19", interval_MHZ19_in_Seconds);
-	}
 	if (request->hasParam("intervalBME680"))
-	{
 		configHandler.setConfigInterval("intervalBME680", request->getParam("intervalBME680")->value().toInt());
-	}
-	else
-	{
-		Serial.printf("[WebServer] intervalBME680 missing, using default: %ds\n", interval_BME680_in_Seconds);
-		configHandler.setConfigInterval("intervalBME680", interval_BME680_in_Seconds);
-	}
-	if (request->hasParam("intervalWiFi"))
-	{
-		configHandler.setConfigInterval("intervalWiFi", request->getParam("intervalWiFi")->value().toInt());
-	}
-	else
-	{
-		Serial.printf("[WebServer] intervalWiFi missing, using default: %ds\n", interval_WiFiCheck_in_Seconds);
-		configHandler.setConfigInterval("intervalWiFi", interval_WiFiCheck_in_Seconds);
-	}
 	if (request->hasParam("intervalPRINT"))
-	{
 		configHandler.setConfigInterval("intervalPRINT", request->getParam("intervalPRINT")->value().toInt());
-	}
-	else
-	{
-		Serial.printf("[WebServer] intervalPRINT missing, using default: %ds\n", interval_RAMPrintout_in_Seconds);
-		configHandler.setConfigInterval("intervalPRINT", interval_RAMPrintout_in_Seconds);
-	}
-	if (request->hasParam("intervalEPD"))
-	{
-		configHandler.setConfigInterval("intervalEPD", request->getParam("intervalEPD")->value().toInt());
-	}
-	else
-	{
-		Serial.printf("[WebServer] intervalEPD missing, using default: %ds\n", interval_EPD_in_Seconds);
-		configHandler.setConfigInterval("intervalEPD", interval_EPD_in_Seconds);
-	}
-	if (request->hasParam("intervalLED"))
-	{
-		configHandler.setConfigInterval("intervalLED", request->getParam("intervalLED")->value().toInt());
-	}
-	else
-	{
-		Serial.printf("[WebServer] intervalLED missing, using default: %ds\n", interval_LED_in_Seconds);
-		configHandler.setConfigInterval("intervalLED", interval_LED_in_Seconds);
-	}
 	if (request->hasParam("intervalMQTT"))
-	{
 		configHandler.setConfigInterval("intervalMQTT", request->getParam("intervalMQTT")->value().toInt());
-	}
-	else
-	{
-		Serial.printf("[WebServer] intervalMQTT missing, using default: %ds\n", interval_mqtt_in_Seconds);
-		configHandler.setConfigInterval("intervalMQTT", interval_mqtt_in_Seconds);
-	}
 	configHandler.persistAllSettings();
 	request->send(200, "text/plain", "Interval Settings Saved!");
-	request->redirect("/sensorsettings");
 }
 
-void WebServerHandler::handle_submit_modulswitch(AsyncWebServerRequest *request)
+void WebServerHandler::handle_submit_wlansettings(AsyncWebServerRequest *request)
 {
-	if (request->hasParam("switchWIFI"))
-	{
-		configHandler.setConfigSwitch("switchWIFI", atoi(request->getParam("switchWIFI")->value().c_str()));
-	}
-	configHandler.setConfigSwitch("switchEPD", request->hasParam("switchEPD", true) ? 1 : 0);
-
-	if (request->hasParam("switchEPDorientation", true))
-	{
-		configHandler.setConfigSwitch("switchEPDorientation", request->getParam("switchEPDorientation", true)->value().toInt());
-	}
-
-
-	if (request->hasParam("switchLED"))
-	{
-		configHandler.setConfigSwitch("switchLED", atoi(request->getParam("switchLED")->value().c_str()));
-	}
+	configHandler.setConfigSwitch("switchWIFI",
+		request->hasParam("switchWIFI") ? request->getParam("switchWIFI")->value().toInt() : 0);
+	if (request->hasParam("intervalWiFi"))
+		configHandler.setConfigInterval("intervalWiFi", request->getParam("intervalWiFi")->value().toInt());
 	configHandler.persistAllSettings();
-	request->send(200, "text/plain", "Modul Settings Saved!");
-	request->redirect("/sensorsettings");
+	request->send(200, "text/plain", "WLAN Settings Saved!");
 }
 
-void WebServerHandler::handle_submit_ledconfig(AsyncWebServerRequest *request)
+void WebServerHandler::handle_submit_ledsettings(AsyncWebServerRequest *request)
 {
-    if (request->hasParam("LEDbrightness", true)) // Prüft POST-Parameter
-    {
-        int brightness = request->getParam("LEDbrightness", true)->value().toInt();
-        configHandler.setConfigLED("LEDbrightness", brightness);
-
-        LEDHandler &ledhandler = LEDHandler::getInstance();
-        ledhandler.updateLEDBrightness(brightness);
-    }
-    else
-    {
-        request->send(400, "text/plain", "Bad Request: Missing parameters");
-        return;
-    }
+	configHandler.setConfigSwitch("switchLED",
+		request->hasParam("switchLED") ? request->getParam("switchLED")->value().toInt() : 0);
+	if (request->hasParam("LEDbrightness")) {
+		int brightness = request->getParam("LEDbrightness")->value().toInt();
+		configHandler.setConfigLED("LEDbrightness", brightness);
+		LEDHandler::getInstance().updateLEDBrightness(brightness);
+	}
+	if (request->hasParam("intervalLED"))
+		configHandler.setConfigInterval("intervalLED", request->getParam("intervalLED")->value().toInt());
 	configHandler.persistAllSettings();
-    request->send(200, "text/plain", "LED Settings Saved!");
-    request->redirect("/sensorsettings");
+	request->send(200, "text/plain", "LED Settings Saved!");
+}
+
+void WebServerHandler::handle_submit_epdsettings(AsyncWebServerRequest *request)
+{
+	configHandler.setConfigSwitch("switchEPD",
+		request->hasParam("switchEPD") ? request->getParam("switchEPD")->value().toInt() : 0);
+	if (request->hasParam("switchEPDorientation"))
+		configHandler.setConfigSwitch("switchEPDorientation",
+			request->getParam("switchEPDorientation")->value().toInt());
+	if (request->hasParam("intervalEPD"))
+		configHandler.setConfigInterval("intervalEPD", request->getParam("intervalEPD")->value().toInt());
+	configHandler.persistAllSettings();
+	request->send(200, "text/plain", "Display Settings Saved!");
+}
+
+void WebServerHandler::handle_page_led(AsyncWebServerRequest *request)
+{
+	File file = LittleFS.open("/static/led.htm", "r");
+	if (!file)
+	{
+		request->send(500, "text/plain", "Internal Server Error: Cannot open led.htm");
+		return;
+	}
+	String content = file.readString();
+	file.close();
+	content.replace("{{deviceName}}", DEVICE_NAME);
+	content.replace("{{switchLED_checked}}", configHandler.getConfigSwitch("switchLED") ? "checked" : "");
+	content.replace("{{LEDbrightness}}", String(configHandler.getConfigLED("LEDbrightness")));
+	content.replace("{{intervalLED}}", String(configHandler.getConfigInterval("intervalLED")));
+	request->send(200, "text/html; charset=utf-8", content);
+}
+
+void WebServerHandler::handle_page_epd(AsyncWebServerRequest *request)
+{
+	File file = LittleFS.open("/static/epd.htm", "r");
+	if (!file)
+	{
+		request->send(500, "text/plain", "Internal Server Error: Cannot open epd.htm");
+		return;
+	}
+	String content = file.readString();
+	file.close();
+	content.replace("{{deviceName}}", DEVICE_NAME);
+	content.replace("{{switchEPD_checked}}", configHandler.getConfigSwitch("switchEPD") ? "checked" : "");
+	int epdOri = configHandler.getConfigSwitch("switchEPDorientation");
+	content.replace("{{epdOrientation_0}}", epdOri == 0 ? "selected" : "");
+	content.replace("{{epdOrientation_1}}", epdOri == 1 ? "selected" : "");
+	content.replace("{{epdOrientation_2}}", epdOri == 2 ? "selected" : "");
+	content.replace("{{epdOrientation_3}}", epdOri == 3 ? "selected" : "");
+	content.replace("{{intervalEPD}}", String(configHandler.getConfigInterval("intervalEPD")));
+	request->send(200, "text/html; charset=utf-8", content);
 }
 
 void WebServerHandler::handle_submit_sensorconfig(AsyncWebServerRequest *request)
@@ -409,6 +385,11 @@ void WebServerHandler::handle_submit_sensorconfig(AsyncWebServerRequest *request
     if (request->hasParam("TEMPERATUR_OFFSET", true)) {
         float tempOffset = request->getParam("TEMPERATUR_OFFSET", true)->value().toFloat();
         configHandler.setConfigSensor("tempOffset", (int)(tempOffset * 10));
+        updated = true;
+    }
+    if (request->hasParam("sensorMHZ19variant", true)) {
+        int variant = request->getParam("sensorMHZ19variant", true)->value().toInt();
+        configHandler.setConfigSensor("sensorMHZ19variant", variant);
         updated = true;
     }
 

--- a/src/WebServerHandler.h
+++ b/src/WebServerHandler.h
@@ -47,6 +47,12 @@ private:
 	void handle_option_calibrate_mhz19(AsyncWebServerRequest *request);
 
 
+	void handle_page_led(AsyncWebServerRequest *request);
+	void handle_page_epd(AsyncWebServerRequest *request);
+	void handle_submit_wlansettings(AsyncWebServerRequest *request);
+	void handle_submit_ledsettings(AsyncWebServerRequest *request);
+	void handle_submit_epdsettings(AsyncWebServerRequest *request);
+
 	void handle_page_mqtt(AsyncWebServerRequest *request);
 	void handle_submit_mqttconfig(AsyncWebServerRequest *request);
 	void handle_api_mqtt_status(AsyncWebServerRequest *request);


### PR DESCRIPTION
Navigation
- Add LED Settings (/led) and Display Settings (/epd) to index page

Sensor Settings (/sensorsettings)
- Remove WiFi, LED, and EPD controls (moved to dedicated pages)
- Keep only sensor-related intervals (MHZ19, BME680, PRINT, MQTT)
- Show auto-detected MH-Z19 variant as read-only label
- Add variant override select (Auto / Original / B/C), saved via /submitSensorConfig

WLAN Settings (/WLAN)
- Add WiFi Check enable/disable toggle
- Add WiFi Check Interval field
- New endpoint /submitWLANsettings handles switch + interval without restart

LED Settings (/led) — new page
- LED enable/disable toggle
- Brightness slider
- LED update interval
- Single form submitted to /submitLEDsettings

Display Settings (/epd) — new page
- EPD enable/disable toggle
- Orientation select (all 4 options with cable direction labels)
- Refresh interval
- "Refresh Display Now" button
- Single form submitted to /submitEPDsettings

Backend (WebServerHandler)
- Register static file routes for led.htm and epd.htm
- Add page handlers: handle_page_led, handle_page_epd
- Add submit handlers: handle_submit_wlansettings, handle_submit_ledsettings, handle_submit_epdsettings
- Remove handle_submit_modulswitch and handle_submit_ledconfig (replaced)
- handle_submit_sensorconfig now also handles sensorMHZ19variant
- handle_submit_modulinterval reduced to sensor-only intervals
- handle_page_settings calls MHZ19Handler::getSensorVariantName() to inject the detected variant string into the template